### PR TITLE
Allow to provide default labels and resources for StaticNode

### DIFF
--- a/tests/extra/test_static_node.py
+++ b/tests/extra/test_static_node.py
@@ -40,3 +40,14 @@ def test_static_node_without_cgroups():
 def test_static_node_with_cgroups_but_require_pids():
     static_node = StaticNode(tasks=['task1'], require_pids=True)
     assert static_node.get_tasks() == []
+
+
+@patch('os.path.exists', Mock(return_value=True))
+@patch('builtins.open', mock_open(read_data='100'))
+def test_static_node_with_labels_and_resources():
+    static_node = StaticNode(tasks=['task1'], default_labels=dict(foo='bar'),
+                             default_resources=dict(cpu=1))
+    assert static_node.get_tasks() == [Task(
+        name='task1', task_id='task1', cgroup_path='/task1',
+        labels={'foo': 'bar'}, resources={'cpu': 1}, subcgroups_paths=[]
+    )]

--- a/wca/extra/static_node.py
+++ b/wca/extra/static_node.py
@@ -14,9 +14,9 @@
 
 import logging
 import os
-from typing import List
+from typing import List, Dict, Union
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from wca.config import Str
 from wca.nodes import Node, Task
@@ -40,6 +40,8 @@ class StaticNode(Node):
     # List of task names.
     tasks: List[Str]
     require_pids: bool = False
+    default_labels: Dict[Str, Str] = field(default_factory=dict)
+    default_resources: Dict[Str, Union[Str, float]] = field(default_factory=dict)
 
     _BASE_CGROUP_PATH = '/sys/fs/cgroup'
     _REQUIRED_CONTROLLERS = ('cpu', 'cpuacct', 'perf_event')
@@ -64,8 +66,8 @@ class StaticNode(Node):
                         name=task_name,
                         task_id=task_name,
                         cgroup_path='/%s' % task_name,
-                        labels={},
-                        resources={},
+                        labels=dict(self.default_labels),
+                        resources=dict(self.default_resources),
                         subcgroups_paths=[]
                     )
                 )


### PR DESCRIPTION
Some plugins like PRM, require resources to be provided. To be able to test those, this commit 
allows to specify dummy default labels and resource to be returned by static node for all tasks.

Can be further extend to specify tasks specific labels/resource in follow up PR.