### PR TITLE
Fix time wait/action delay

### DIFF
--- a/wca/runners/measurement.py
+++ b/wca/runners/measurement.py
@@ -93,10 +93,10 @@ class MeasurementRunner(Runner):
         """
         now = time.time()
         iteration_duration = now - self._last_iteration
-        self._last_iteration = now
 
         residual_time = max(0., self._action_delay - iteration_duration)
         time.sleep(residual_time)
+        self._last_iteration = time.time()
 
     def _initialize(self) -> Optional[int]:
         """Check privileges, RDT availability and prepare internal state.


### PR DESCRIPTION
The last iteration property in runner was improperly set to moment before sleep, so nest iteration sleep was skipped. The result was that wca iterations were called twice more than expected. PR include tests.