### PR TITLE
Fix handling PEM in SSL

### DIFF
--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -96,20 +96,25 @@ def test_privileges_not_root_capabilities_no_dac_paranoid_setuid(capget, read_pa
     assert not wca.security.are_privileges_sufficient(True)
 
 
-def test_ssl_raise_error_if_only_client_key_is_provided():
+def test_ssl_error_only_client_key():
+    """Tests that SSL throws ValidationError when only client key path is provided."""
     with pytest.raises(ValidationError):
         wca.security.SSL(client_key_path='/key')
 
 
-def test_ssl_not_raise_error_when_client_both_certificate_and_key_is_provided_in_single_file():
+def test_ssl_accept_single_file():
+    """Tests that SSL accepts single file with client certificate and key."""
     wca.security.SSL(client_cert_path='/cert.pem')
 
 
-def test_ssl_get_client_certs_return_path_to_single_file_with_client_certificate_and_key():
+def test_ssl_get_client_certs_single_file():
+    """Tests that get_client_certs() returns file path with client certificate and key."""
     ssl = wca.security.SSL(client_cert_path='/cert.pem')
+    assert ssl.client_key_path is None
     assert ssl.get_client_certs() == '/cert.pem'
 
 
-def test_ssl_get_client_certs_return_tuple_with_client_key_and_cert_paths():
+def test_ssl_get_client_certs_tuple():
+    """Tests that get_client_certs() returns tuple with client certificate and key paths."""
     ssl = wca.security.SSL(client_cert_path='/cert', client_key_path='/key')
     assert ssl.get_client_certs() == ('/cert', '/key')

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -105,7 +105,7 @@ def test_ssl_not_raise_error_when_client_both_certificate_and_key_is_provided_in
     wca.security.SSL(client_cert_path='/cert.pem')
 
 
-def test_ssl_get_client_certs_return_path_to__single_file_with_client_certificate_and_key():
+def test_ssl_get_client_certs_return_path_to_single_file_with_client_certificate_and_key():
     ssl = wca.security.SSL(client_cert_path='/cert.pem')
     assert ssl.get_client_certs() == '/cert.pem'
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -101,11 +101,7 @@ def test_ssl_raise_error_if_only_client_key_is_provided():
         wca.security.SSL(client_key_path='/key')
 
 
-def test_ssl_raise_error_if_only_client_cert_is_provided():
-    with pytest.raises(ValidationError):
-        wca.security.SSL(client_cert_path='/cert')
-
-
+# PEM file can be passed without extension!
 def test_ssl_not_raise_error_when_client_pem_file_is_provided():
     wca.security.SSL(client_cert_path='/cert.pem')
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -105,7 +105,7 @@ def test_ssl_not_raise_error_when_client_both_certificate_and_key_is_provided_in
     wca.security.SSL(client_cert_path='/cert.pem')
 
 
-def test_ssl_get_client_certs_return_path_to_client_single_file_with_certificate_and_key():
+def test_ssl_get_client_certs_return_path_to__single_file_with_client_certificate_and_key():
     ssl = wca.security.SSL(client_cert_path='/cert.pem')
     assert ssl.get_client_certs() == '/cert.pem'
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -101,12 +101,11 @@ def test_ssl_raise_error_if_only_client_key_is_provided():
         wca.security.SSL(client_key_path='/key')
 
 
-# PEM file can be passed without extension!
-def test_ssl_not_raise_error_when_client_pem_file_is_provided():
+def test_ssl_not_raise_error_when_client_both_certificate_and_key_is_provided_in_single_file():
     wca.security.SSL(client_cert_path='/cert.pem')
 
 
-def test_ssl_get_client_certs_return_path_to_client_pem_file():
+def test_ssl_get_client_certs_return_path_to_client_single_file_with_certificate_and_key():
     ssl = wca.security.SSL(client_cert_path='/cert.pem')
     assert ssl.get_client_certs() == '/cert.pem'
 

--- a/wca/security.py
+++ b/wca/security.py
@@ -120,20 +120,10 @@ class SSL:
 
     def __post_init__(self):
 
-        if self.client_cert_path:
-            client_cert_filename = os.path.basename(self.client_cert_path)
-            client_cert_extension = os.path.splitext(client_cert_filename)[1]
-
-            if client_cert_extension == '.pem':
-                # .pem file consists both client cert and key data so ignore client_key_path.
-                return
-            else:
-                if not self.client_key_path:
-                    raise ValidationError(
-                        'Client certiticate provided but without client private key!')
-        elif self.client_key_path:
+        if self.client_key_path and not self.client_cert_path:
             # There is only client key path, that is wrong, throw error.
-            raise ValidationError('Client private key provided but without certificate path!')
+            raise ValidationError(
+                    'Provided client key without certificate!')
 
     def get_client_certs(self):
         """Return client cert and key path.


### PR DESCRIPTION
Certifcates and keys cannot be described by their extension. Also there are more types of encodings...