### PR TITLE
Handle missing cgroup for Mesos executor process

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "347255dd5cc5e2d57089eaf3297d98eceac3e9958a8d82e6f9a29c2105e24016"
+            "sha256": "9c307d6e5d15f8112d99cb6e0c642e48c0b408adc836922ef5446cc8a715eb07"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -173,39 +173,40 @@
         },
         "coverage": {
             "hashes": [
-                "sha256:3684fabf6b87a369017756b551cef29e505cb155ddb892a7a29277b978da88b9",
-                "sha256:39e088da9b284f1bd17c750ac672103779f7954ce6125fd4382134ac8d152d74",
-                "sha256:3c205bc11cc4fcc57b761c2da73b9b72a59f8d5ca89979afb0c1c6f9e53c7390",
-                "sha256:465ce53a8c0f3a7950dfb836438442f833cf6663d407f37d8c52fe7b6e56d7e8",
-                "sha256:48020e343fc40f72a442c8a1334284620f81295256a6b6ca6d8aa1350c763bbe",
-                "sha256:5296fc86ab612ec12394565c500b412a43b328b3907c0d14358950d06fd83baf",
-                "sha256:5f61bed2f7d9b6a9ab935150a6b23d7f84b8055524e7be7715b6513f3328138e",
-                "sha256:68a43a9f9f83693ce0414d17e019daee7ab3f7113a70c79a3dd4c2f704e4d741",
-                "sha256:6b8033d47fe22506856fe450470ccb1d8ba1ffb8463494a15cfc96392a288c09",
-                "sha256:7ad7536066b28863e5835e8cfeaa794b7fe352d99a8cded9f43d1161be8e9fbd",
-                "sha256:7bacb89ccf4bedb30b277e96e4cc68cd1369ca6841bde7b005191b54d3dd1034",
-                "sha256:839dc7c36501254e14331bcb98b27002aa415e4af7ea039d9009409b9d2d5420",
-                "sha256:8f9a95b66969cdea53ec992ecea5406c5bd99c9221f539bca1e8406b200ae98c",
-                "sha256:932c03d2d565f75961ba1d3cec41ddde00e162c5b46d03f7423edcb807734eab",
-                "sha256:988529edadc49039d205e0aa6ce049c5ccda4acb2d6c3c5c550c17e8c02c05ba",
-                "sha256:998d7e73548fe395eeb294495a04d38942edb66d1fa61eb70418871bc621227e",
-                "sha256:9de60893fb447d1e797f6bf08fdf0dbcda0c1e34c1b06c92bd3a363c0ea8c609",
-                "sha256:9e80d45d0c7fcee54e22771db7f1b0b126fb4a6c0a2e5afa72f66827207ff2f2",
-                "sha256:a545a3dfe5082dc8e8c3eb7f8a2cf4f2870902ff1860bd99b6198cfd1f9d1f49",
-                "sha256:a5d8f29e5ec661143621a8f4de51adfb300d7a476224156a39a392254f70687b",
-                "sha256:aca06bfba4759bbdb09bf52ebb15ae20268ee1f6747417837926fae990ebc41d",
-                "sha256:bb23b7a6fd666e551a3094ab896a57809e010059540ad20acbeec03a154224ce",
-                "sha256:bfd1d0ae7e292105f29d7deaa9d8f2916ed8553ab9d5f39ec65bcf5deadff3f9",
-                "sha256:c62ca0a38958f541a73cf86acdab020c2091631c137bd359c4f5bddde7b75fd4",
-                "sha256:c709d8bda72cf4cd348ccec2a4881f2c5848fd72903c185f363d361b2737f773",
-                "sha256:c968a6aa7e0b56ecbd28531ddf439c2ec103610d3e2bf3b75b813304f8cb7723",
-                "sha256:df785d8cb80539d0b55fd47183264b7002077859028dfe3070cf6359bf8b2d9c",
-                "sha256:f406628ca51e0ae90ae76ea8398677a921b36f0bd71aab2099dfed08abd0322f",
-                "sha256:f46087bbd95ebae244a0eda01a618aff11ec7a069b15a3ef8f6b520db523dcf1",
-                "sha256:f8019c5279eb32360ca03e9fac40a12667715546eed5c5eb59eb381f2f501260",
-                "sha256:fc5f4d209733750afd2714e9109816a29500718b32dd9a5db01c0cb3a019b96a"
+                "sha256:08907593569fe59baca0bf152c43f3863201efb6113ecb38ce7e97ce339805a6",
+                "sha256:0be0f1ed45fc0c185cfd4ecc19a1d6532d72f86a2bac9de7e24541febad72650",
+                "sha256:141f08ed3c4b1847015e2cd62ec06d35e67a3ac185c26f7635f4406b90afa9c5",
+                "sha256:19e4df788a0581238e9390c85a7a09af39c7b539b29f25c89209e6c3e371270d",
+                "sha256:23cc09ed395b03424d1ae30dcc292615c1372bfba7141eb85e11e50efaa6b351",
+                "sha256:245388cda02af78276b479f299bbf3783ef0a6a6273037d7c60dc73b8d8d7755",
+                "sha256:331cb5115673a20fb131dadd22f5bcaf7677ef758741312bee4937d71a14b2ef",
+                "sha256:386e2e4090f0bc5df274e720105c342263423e77ee8826002dcffe0c9533dbca",
+                "sha256:3a794ce50daee01c74a494919d5ebdc23d58873747fa0e288318728533a3e1ca",
+                "sha256:60851187677b24c6085248f0a0b9b98d49cba7ecc7ec60ba6b9d2e5574ac1ee9",
+                "sha256:63a9a5fc43b58735f65ed63d2cf43508f462dc49857da70b8980ad78d41d52fc",
+                "sha256:6b62544bb68106e3f00b21c8930e83e584fdca005d4fffd29bb39fb3ffa03cb5",
+                "sha256:6ba744056423ef8d450cf627289166da65903885272055fb4b5e113137cfa14f",
+                "sha256:7494b0b0274c5072bddbfd5b4a6c6f18fbbe1ab1d22a41e99cd2d00c8f96ecfe",
+                "sha256:826f32b9547c8091679ff292a82aca9c7b9650f9fda3e2ca6bf2ac905b7ce888",
+                "sha256:93715dffbcd0678057f947f496484e906bf9509f5c1c38fc9ba3922893cda5f5",
+                "sha256:9a334d6c83dfeadae576b4d633a71620d40d1c379129d587faa42ee3e2a85cce",
+                "sha256:af7ed8a8aa6957aac47b4268631fa1df984643f07ef00acd374e456364b373f5",
+                "sha256:bf0a7aed7f5521c7ca67febd57db473af4762b9622254291fbcbb8cd0ba5e33e",
+                "sha256:bf1ef9eb901113a9805287e090452c05547578eaab1b62e4ad456fcc049a9b7e",
+                "sha256:c0afd27bc0e307a1ffc04ca5ec010a290e49e3afbe841c5cafc5c5a80ecd81c9",
+                "sha256:dd579709a87092c6dbee09d1b7cfa81831040705ffa12a1b248935274aee0437",
+                "sha256:df6712284b2e44a065097846488f66840445eb987eb81b3cc6e4149e7b6982e1",
+                "sha256:e07d9f1a23e9e93ab5c62902833bf3e4b1f65502927379148b6622686223125c",
+                "sha256:e2ede7c1d45e65e209d6093b762e98e8318ddeff95317d07a27a2140b80cfd24",
+                "sha256:e4ef9c164eb55123c62411f5936b5c2e521b12356037b6e1c2617cef45523d47",
+                "sha256:eca2b7343524e7ba246cab8ff00cab47a2d6d54ada3b02772e908a45675722e2",
+                "sha256:eee64c616adeff7db37cc37da4180a3a5b6177f5c46b187894e633f088fb5b28",
+                "sha256:ef824cad1f980d27f26166f86856efe11eff9912c4fed97d3804820d43fa550c",
+                "sha256:efc89291bd5a08855829a3c522df16d856455297cf35ae827a37edac45f466a7",
+                "sha256:fa964bae817babece5aa2e8c1af841bebb6d0b9add8e637548809d040443fee0",
+                "sha256:ff37757e068ae606659c28c3bd0d923f9d29a85de79bf25b2b34b148473b5025"
             ],
-            "version": "==4.5.3"
+            "version": "==4.5.4"
         },
         "entrypoints": {
             "hashes": [
@@ -231,17 +232,17 @@
         },
         "gitpython": {
             "hashes": [
-                "sha256:563221e5a44369c6b79172f455584c9ebbb122a13368cc82cb4b5addff788f82",
-                "sha256:8237dc5bfd6f1366abeee5624111b9d6879393d84745a507de0fda86043b65a8"
+                "sha256:c15c55ff890cd3a6a8330059e80885410a328f645551b55a91d858bfb3eb2573",
+                "sha256:df752b6b6f06f11213e91c4925aea7eaf9e37e88fb71c8a7a1aa0a5c10852120"
             ],
-            "version": "==2.1.11"
+            "version": "==2.1.13"
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:6dfd58dfe281e8d240937776065dd3624ad5469c835248219bd16cf2e12dbeb7",
-                "sha256:cb6ee23b46173539939964df59d3d72c3e0c1b5d54b84f1d8a7e912fe43612db"
+                "sha256:23d3d873e008a513952355379d93cbcab874c58f4f034ff657c7a87422fa64e8",
+                "sha256:80d2de76188eabfbfcf27e6a37342c2827801e59c4cc14b0371c56fed43820e3"
             ],
-            "version": "==0.18"
+            "version": "==0.19"
         },
         "mccabe": {
             "hashes": [
@@ -252,25 +253,25 @@
         },
         "more-itertools": {
             "hashes": [
-                "sha256:2112d2ca570bb7c3e53ea1a35cd5df42bb0fd10c45f0fb97178679c3c03d64c7",
-                "sha256:c3e4748ba1aad8dba30a4886b0b1a2004f9a863837b8654e7059eebf727afa5a"
+                "sha256:409cd48d4db7052af495b09dec721011634af3753ae1ef92d2b32f73a745f832",
+                "sha256:92b8c4b06dac4f0611c0729b2f2ede52b2e1bac1ab48f089c7ddc12e26bb60c4"
             ],
             "markers": "python_version > '2.7'",
-            "version": "==7.0.0"
+            "version": "==7.2.0"
         },
         "packaging": {
             "hashes": [
-                "sha256:0c98a5d0be38ed775798ece1b9727178c4469d9c3b4ada66e8e6b7849f8732af",
-                "sha256:9e1cbf8c12b1f1ce0bb5344b8d7ecf66a6f8a6e91bcb0c84593ed6d3ab5c4ab3"
+                "sha256:a7ac867b97fdc07ee80a8058fe4435ccd274ecc3b0ed61d852d7d53055528cf9",
+                "sha256:c491ca87294da7cc01902edbe30a5bc6c4c28172b5138ab4e4aa1b9d7bfaeafe"
             ],
-            "version": "==19.0"
+            "version": "==19.1"
         },
         "pbr": {
             "hashes": [
-                "sha256:9181e2a34d80f07a359ff1d0504fad3a47e00e1cf2c475b0aa7dcb030af54c40",
-                "sha256:94bdc84da376b3dd5061aa0c3b6faffe943ee2e56fa4ff9bd63e1643932f34fc"
+                "sha256:56e52299170b9492513c64be44736d27a512fa7e606f21942160b68ce510b4bc",
+                "sha256:9b321c204a88d8ab5082699469f52cc94c5da45c51f114113d01b3d993c24cdf"
             ],
-            "version": "==5.3.1"
+            "version": "==5.4.2"
         },
         "pex": {
             "hashes": [
@@ -310,10 +311,10 @@
         },
         "pyparsing": {
             "hashes": [
-                "sha256:1873c03321fc118f4e9746baf201ff990ceb915f433f23b395f5580d1840cb2a",
-                "sha256:9b6323ef4ab914af344ba97510e966d64ba91055d6b9afa6b30799340e89cc03"
+                "sha256:6f98a7b9397e206d78cc01df10131398f1c8b8510a2f4d97d9abd82e1aacdd80",
+                "sha256:d9338df12903bbf5d65a0e4e87c2161968b10d2e489652bb47001d82a9b028b4"
             ],
-            "version": "==2.4.0"
+            "version": "==2.4.2"
         },
         "pytest": {
             "hashes": [
@@ -333,19 +334,21 @@
         },
         "pyyaml": {
             "hashes": [
-                "sha256:57acc1d8533cbe51f6662a55434f0dbecfa2b9eaf115bede8f6fd00115a0c0d3",
-                "sha256:588c94b3d16b76cfed8e0be54932e5729cc185caffaa5a451e7ad2f7ed8b4043",
-                "sha256:68c8dd247f29f9a0d09375c9c6b8fdc64b60810ebf07ba4cdd64ceee3a58c7b7",
-                "sha256:70d9818f1c9cd5c48bb87804f2efc8692f1023dac7f1a1a5c61d454043c1d265",
-                "sha256:86a93cccd50f8c125286e637328ff4eef108400dd7089b46a7be3445eecfa391",
-                "sha256:a0f329125a926876f647c9fa0ef32801587a12328b4a3c741270464e3e4fa778",
-                "sha256:a3c252ab0fa1bb0d5a3f6449a4826732f3eb6c0270925548cac342bc9b22c225",
-                "sha256:b4bb4d3f5e232425e25dda21c070ce05168a786ac9eda43768ab7f3ac2770955",
-                "sha256:cd0618c5ba5bda5f4039b9398bb7fb6a317bb8298218c3de25c47c4740e4b95e",
-                "sha256:ceacb9e5f8474dcf45b940578591c7f3d960e82f926c707788a570b51ba59190",
-                "sha256:fe6a88094b64132c4bb3b631412e90032e8cfe9745a58370462240b8cb7553cd"
+                "sha256:0113bc0ec2ad727182326b61326afa3d1d8280ae1122493553fd6f4397f33df9",
+                "sha256:01adf0b6c6f61bd11af6e10ca52b7d4057dd0be0343eb9283c878cf3af56aee4",
+                "sha256:5124373960b0b3f4aa7df1707e63e9f109b5263eca5976c66e08b1c552d4eaf8",
+                "sha256:5ca4f10adbddae56d824b2c09668e91219bb178a1eee1faa56af6f99f11bf696",
+                "sha256:7907be34ffa3c5a32b60b95f4d95ea25361c951383a894fec31be7252b2b6f34",
+                "sha256:7ec9b2a4ed5cad025c2278a1e6a19c011c80a3caaac804fd2d329e9cc2c287c9",
+                "sha256:87ae4c829bb25b9fe99cf71fbb2140c448f534e24c998cc60f39ae4f94396a73",
+                "sha256:9de9919becc9cc2ff03637872a440195ac4241c80536632fffeb6a1e25a74299",
+                "sha256:a5a85b10e450c66b49f98846937e8cfca1db3127a9d5d1e31ca45c3d0bef4c5b",
+                "sha256:b0997827b4f6a7c286c01c5f60384d218dca4ed7d9efa945c3e1aa623d5709ae",
+                "sha256:b631ef96d3222e62861443cc89d6563ba3eeb816eeb96b2629345ab795e53681",
+                "sha256:bf47c0607522fdbca6c9e817a6e81b08491de50f3766a7a0e6a5be7905961b41",
+                "sha256:f81025eddd0327c7d4cfe9b62cf33190e1e736cc6e97502b3ec425f574b3e7a8"
             ],
-            "version": "==5.1.1"
+            "version": "==5.1.2"
         },
         "setuptools-scm": {
             "hashes": [
@@ -385,10 +388,10 @@
         },
         "zipp": {
             "hashes": [
-                "sha256:8c1019c6aad13642199fbe458275ad6a84907634cc9f0989877ccc4a2840139d",
-                "sha256:ca943a7e809cc12257001ccfb99e3563da9af99d52f261725e96dfe0f9275bc3"
+                "sha256:4970c3758f4e89a7857a973b1e2a5d75bcdc47794442f2e2dd4fe8e0466e809a",
+                "sha256:8a5712cfd3bb4248015eb3b0b3c54a5f6ee3f2425963ef2a0125b8bc40aafaec"
             ],
-            "version": "==0.5.1"
+            "version": "==0.5.2"
         }
     }
 }

--- a/tests/test_mesos.py
+++ b/tests/test_mesos.py
@@ -17,9 +17,9 @@ from unittest.mock import patch
 
 import pytest
 
+from tests.testing import create_json_fixture_mock, create_open_mock
 from wca.config import ValidationError
 from wca.mesos import MesosNode, MesosTask
-from tests.testing import create_json_fixture_mock, create_open_mock
 
 
 @patch('requests.post', return_value=create_json_fixture_mock('mesos_get_state', __file__))
@@ -49,14 +49,16 @@ def test_get_tasks(find_cgroup_mock, post_mock):
         resources={'mem': 2048.0, 'cpus': 8.0, 'disk': 10240.0}
     )
 
+
 @patch('requests.post', return_value=create_json_fixture_mock('mesos_get_state', __file__))
 @patch('builtins.open', new=create_open_mock({
     "/proc/32620/cgroup": "2:cpuacct,cpu:/",
 }))
-def test_get_tasks(post_mock):
+def test_get_tasks_with_wrong_cgroup(post_mock):
     node = MesosNode()
     tasks = set(node.get_tasks())  # Wrap with set to make sure that hash is implemented.
     assert len(tasks) == 0
+
 
 @pytest.mark.parametrize(
     "json_mock", [create_json_fixture_mock('missing_executor_pid_in_mesos_response', __file__),

--- a/tests/test_mesos.py
+++ b/tests/test_mesos.py
@@ -19,7 +19,7 @@ import pytest
 
 from wca.config import ValidationError
 from wca.mesos import MesosNode, MesosTask
-from tests.testing import create_json_fixture_mock
+from tests.testing import create_json_fixture_mock, create_open_mock
 
 
 @patch('requests.post', return_value=create_json_fixture_mock('mesos_get_state', __file__))
@@ -49,6 +49,14 @@ def test_get_tasks(find_cgroup_mock, post_mock):
         resources={'mem': 2048.0, 'cpus': 8.0, 'disk': 10240.0}
     )
 
+@patch('requests.post', return_value=create_json_fixture_mock('mesos_get_state', __file__))
+@patch('builtins.open', new=create_open_mock({
+    "/proc/32620/cgroup": "2:cpuacct,cpu:/",
+}))
+def test_get_tasks(post_mock):
+    node = MesosNode()
+    tasks = set(node.get_tasks())  # Wrap with set to make sure that hash is implemented.
+    assert len(tasks) == 0
 
 @pytest.mark.parametrize(
     "json_mock", [create_json_fixture_mock('missing_executor_pid_in_mesos_response', __file__),

--- a/wca/containers.py
+++ b/wca/containers.py
@@ -218,6 +218,7 @@ class Container(ContainerInterface):
                  enable_derived_metrics: bool = False):
         self._cgroup_path = cgroup_path
         self._name = _sanitize_cgroup_path(self._cgroup_path)
+        assert len(self._name) > 0, 'Container name cannot be empty string!'
         self._allocation_configuration = allocation_configuration
         self._rdt_information = rdt_information
         self._resgroup = resgroup

--- a/wca/mesos.py
+++ b/wca/mesos.py
@@ -78,7 +78,7 @@ def find_cgroup(pid):
                     raise MesosCgroupNotFoundException(
                         'Mesos executor pid=%s found in root cgroup ("/") for %s subsystem in %r. '
                         'Possible explanation: '
-                        ' cgroups/cpu isolator is missing, initialization races' 
+                        ' cgroups/cpu isolator is missing, initialization races'
                         ' or unsupported Mesos software stack'
                         % (pid, CGROUP_DEFAULT_SUBSYSTEM, fname))
                 return path

--- a/wca/mesos.py
+++ b/wca/mesos.py
@@ -67,15 +67,24 @@ class MesosTask(Task):
 def find_cgroup(pid):
     """ Returns cgroup_path relative to 'cpu' subsystem based on /proc/{pid}/cgroup
     with leading '/'"""
-
-    with open(f'/proc/{pid}/cgroup') as f:
-        for line in f:
+    fname = f'/proc/{pid}/cgroup'
+    with open(fname) as f:
+        lines = f.readlines()
+        for line in lines:
             _, subsystems, path = line.strip().split(':')
             subsystems = subsystems.split(',')
             if CGROUP_DEFAULT_SUBSYSTEM in subsystems:
+                if path == '/':
+                    raise MesosCgroupNotFoundException(
+                        'Mesos executor pid=%s found in root cgroup ("/") for %s subsystem in %r. '
+                        'Possible explanation: '
+                        ' cgroups/cpu isolator is missing, initialization races' 
+                        ' or unsupported Mesos software stack'
+                        % (pid, CGROUP_DEFAULT_SUBSYSTEM, fname))
                 return path
-        else:
-            raise MesosCgroupNotFoundException
+
+        raise MesosCgroupNotFoundException(
+            '%r controller not found for pid=%r in %s' % (CGROUP_DEFAULT_SUBSYSTEM, pid, fname))
 
 
 @dataclass
@@ -133,12 +142,13 @@ class MesosNode(Node):
                 continue
 
             executor_pid = last_status['container_status']['executor_pid']
+            task_name = launched_task['name']
 
             try:
                 cgroup_path = find_cgroup(executor_pid)
-            except MesosCgroupNotFoundException:
-                logging.warning(f'Cannot find pid/cgroup mesos path for {executor_pid}. '
-                                f'Ignoring task (inconsistent state returned from Mesos).')
+            except MesosCgroupNotFoundException as e:
+                log.warning('Cannot determine proper cgroup for task=%r! '
+                            'Ignoring this task. Reason: %s', task_name, e)
                 continue
 
             labels = {label['key']: label['value'] for label in launched_task['labels']['labels']}
@@ -151,7 +161,7 @@ class MesosNode(Node):
 
             tasks.append(
                 MesosTask(
-                    name=launched_task['name'],
+                    name=task_name,
                     executor_pid=executor_pid,
                     cgroup_path=cgroup_path,
                     subcgroups_paths=[],

--- a/wca/resctrl.py
+++ b/wca/resctrl.py
@@ -90,6 +90,7 @@ class ResGroup:
             return
 
         log.log(logger.TRACE, 'resctrl: write(%s): number_of_pids=%r', tasks_filepath, len(pids))
+        ftasks = None
         try:
             ftasks = open(tasks_filepath, 'w')
             with SetEffectiveRootUid():
@@ -117,7 +118,8 @@ class ResGroup:
             try:
                 # Try what we can to close the file but it is expected
                 # to fails because the wrong # data is waiting to be flushed
-                ftasks.close()
+                if ftasks is not None:
+                    ftasks.close()
             except (ProcessLookupError, FileNotFoundError, OSError):
                 log.warning('Could not close resctrl/tasks file - ignored!'
                             '(side-effect of previous warning!)')
@@ -137,6 +139,8 @@ class ResGroup:
         """Adds the pids to the resctrl group and creates mongroup with the pids.
            If the resctrl group does not exists creates it (lazy creation).
            If the mongroup exists adds pids to the group (no error will be thrown)."""
+        assert mongroup_name is not None and len(mongroup_name) > 0, 'mongroup_name cannot be empty'
+
         if self.name != RESCTRL_ROOT_NAME:
             log.debug('creating resctrl group %r', self.name)
             self._create_controlgroup_directory()


### PR DESCRIPTION
In case that cgroup path derived from executor process (by its pid) is set to root cgroup, 
ignore such tasks with proper warning and handle that cases in finally clause for synchronizing pids for resctrl.

If this warning happens every iteration for every tasks, it means that unsupported Mesos or its executor/containerizer configuration is in use.
If warning happens rarely, may indicate races when mesos job is initialized.
