### PR TITLE
Replace scaling warning with debug entry

### DIFF
--- a/wca/perf.py
+++ b/wca/perf.py
@@ -183,7 +183,7 @@ def _scale_counter_value(raw_value, time_enabled, time_running) -> (float, float
     if time_running != time_enabled:
         scaling_factor = float(time_enabled) / float(time_running)
         if scaling_factor > SCALING_RATE_WARNING_THRESHOLD:
-            log.warning("Measurement scaling rate: %f", scaling_factor)
+            log.debug("Measurement scaling rate: %f", scaling_factor)
         return round(float(raw_value) * scaling_factor), scaling_factor
     else:
         return float(raw_value), 1.0


### PR DESCRIPTION
For situation that perf subsystem is shared among many applications measurements scaling warning is to verbose and we've already dedicated metrics to inform about scaling issues, called:
- `scaling_factor_avg`
- `scaling_factor_max`

After warning is removed the operator is responsible to watch over those metrics and react if values are to high.