### PR TITLE
Better docs and handling of insufficient privileges.

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -78,13 +78,15 @@ Running WCA as non-root user
 
 WCA processes should not be run with root privileges. Following privileges are needed to run WCA as non-root user:
 
-- `CAP_DAC_OVERRIDE capability`_ - to allow non-root user writing to cgroups and resctrlfs kernel filesystems.
+- `CAP_DAC_OVERRIDE and CAP_SETUID capability`_ - for CPU discover and to allow non-root user writing to cgroups and resctrlfs kernel filesystems.
+- running process with `SECBIT_NO_SETUID_FIXUP`_ secure bit set, to not drop above capabilities when switching to unprileged user,
 - ``/proc/sys/kernel/perf_event_paranoid`` - `content of the file`_ must be set to ``0`` or ``-1`` to allow non-root
   user to collect all the necessary event information.
 
 If it is impossible or undesired to run WCA with privileges outlined above, then you must add ``-0`` (or its
 long form: ``--root``) argument when starting the process)
 
+..  _`SECBIT_NO_SETUID_FIXUP' capability`: https://github.com/torvalds/linux/blob/master/include/uapi/linux/securebits.h#L32
 ..  _`CAP_DAC_OVERRIDE capability`: https://github.com/torvalds/linux/blob/6f0d349d922ba44e4348a17a78ea51b7135965b1/include/uapi/linux/capability.h#L119
 .. _`content of the file`: https://linux.die.net/man/2/perf_event_open
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -78,16 +78,16 @@ Running WCA as non-root user
 
 WCA processes should not be run with root privileges. Following privileges are needed to run WCA as non-root user:
 
-- `CAP_DAC_OVERRIDE and CAP_SETUID capability`_ - for CPU discover and to allow non-root user writing to cgroups and resctrlfs kernel filesystems.
-- running process with `SECBIT_NO_SETUID_FIXUP`_ secure bit set, to not drop above capabilities when switching to unprileged user,
+- `CAP_DAC_OVERRIDE and CAP_SETUID capabilities`_ - for CPU discover and to allow non-root user writing to cgroups and resctrlfs kernel filesystems.
+- running process with `SECBIT_NO_SETUID_FIXUP`_ secure bit set, to not drop above capabilities when switching to unprivileged user,
 - ``/proc/sys/kernel/perf_event_paranoid`` - `content of the file`_ must be set to ``0`` or ``-1`` to allow non-root
   user to collect all the necessary event information.
 
 If it is impossible or undesired to run WCA with privileges outlined above, then you must add ``-0`` (or its
 long form: ``--root``) argument when starting the process)
 
-..  _`SECBIT_NO_SETUID_FIXUP' capability`: https://github.com/torvalds/linux/blob/master/include/uapi/linux/securebits.h#L32
-..  _`CAP_DAC_OVERRIDE capability`: https://github.com/torvalds/linux/blob/6f0d349d922ba44e4348a17a78ea51b7135965b1/include/uapi/linux/capability.h#L119
+..  _`SECBIT_NO_SETUID_FIXUP`: https://github.com/torvalds/linux/blob/master/include/uapi/linux/securebits.h#L32
+..  _`CAP_DAC_OVERRIDE and CAP_SETUID capabilities`: https://github.com/torvalds/linux/blob/6f0d349d922ba44e4348a17a78ea51b7135965b1/include/uapi/linux/capability.h#L119
 .. _`content of the file`: https://linux.die.net/man/2/perf_event_open
 
 Running as systemd service

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -24,7 +24,7 @@ import wca.security
 @patch('wca.security.LIBC.capget', return_value=-1)
 def test_privileges_failed_capget(capget, read_paranoid):
     with pytest.raises(wca.security.GettingCapabilitiesFailed):
-        wca.security.are_privileges_sufficient(True)
+        wca.security.are_privileges_sufficient()
 
 
 def no_cap_dac_override_no_cap_setuid(header, data):
@@ -56,14 +56,14 @@ def cap_dac_override_no_cap_setuid(header, data):
 @patch('wca.security._read_paranoid', return_value=2)
 @patch('wca.security.LIBC.capget', side_effect=no_cap_dac_override_no_cap_setuid)
 def test_privileges_root_no_dac_no_paranoid_no_setuid(capget, read_paranoid, geteuid):
-    assert wca.security.are_privileges_sufficient(True)
+    assert wca.security.are_privileges_sufficient()
 
 
 @patch('os.geteuid', return_value=1000)
 @patch('wca.security._read_paranoid', return_value=2)
 @patch('wca.security.LIBC.capget', side_effect=cap_dac_override_cap_setuid)
 def test_privileges_not_root_no_dac_paranoid_cap_setuid(capget, read_paranoid, geteuid):
-    assert not wca.security.are_privileges_sufficient(True)
+    assert not wca.security.are_privileges_sufficient()
 
 
 @patch('os.geteuid', return_value=1000)
@@ -72,28 +72,28 @@ def test_privileges_not_root_no_dac_paranoid_cap_setuid(capget, read_paranoid, g
 def test_privileges_not_root_no_capabilities_no_dac_paranoid_no_setuid(capget,
                                                                        read_paranoid,
                                                                        geteuid):
-    assert not wca.security.are_privileges_sufficient(True)
+    assert not wca.security.are_privileges_sufficient()
 
 
 @patch('os.geteuid', return_value=1000)
 @patch('wca.security._read_paranoid', return_value=0)
 @patch('wca.security.LIBC.capget', side_effect=cap_dac_override_cap_setuid)
 def test_privileges_not_root_capabilities_dac_paranoid_setuid(capget, read_paranoid, geteuid):
-    assert wca.security.are_privileges_sufficient(True)
+    assert wca.security.are_privileges_sufficient()
 
 
 @patch('os.geteuid', return_value=1000)
 @patch('wca.security._read_paranoid', return_value=0)
 @patch('wca.security.LIBC.capget', side_effect=cap_dac_override_no_cap_setuid)
 def test_privileges_not_root_capabilities_dac_paranoid_no_setuid(capget, read_paranoid, geteuid):
-    assert not wca.security.are_privileges_sufficient(True)
+    assert not wca.security.are_privileges_sufficient()
 
 
 @patch('os.geteuid', return_value=1000)
 @patch('wca.security._read_paranoid', return_value=0)
 @patch('wca.security.LIBC.capget', side_effect=no_cap_dac_override_cap_setuid)
 def test_privileges_not_root_capabilities_no_dac_paranoid_setuid(capget, read_paranoid, geteuid):
-    assert not wca.security.are_privileges_sufficient(True)
+    assert not wca.security.are_privileges_sufficient()
 
 
 def test_ssl_error_only_client_key():

--- a/wca/runners/measurement.py
+++ b/wca/runners/measurement.py
@@ -149,11 +149,13 @@ class MeasurementRunner(Runner):
         """Check privileges, RDT availability and prepare internal state.
         Can return error code that should stop Runner.
         """
-        if not security.are_privileges_sufficient(self._rdt_enabled):
-            log.error("Impossible to use perf_event_open/resctrl subsystems. "
-                      "You need to: adjust /proc/sys/kernel/perf_event_paranoid (set to -1); "
-                      "or has CAP_DAC_OVERRIDE and CAP_SETUID capabilities set."
-                      "You can run process as root too.")
+        if not security.are_privileges_sufficient():
+            log.error("Insufficient privileges! "
+                      "Impossible to use perf_event_open/resctrl subsystems. "
+                      "For unprivileged user it is needed to: "
+                      "adjust /proc/sys/kernel/perf_event_paranoid (set to -1); "
+                      "and has CAP_DAC_OVERRIDE and CAP_SETUID capabilities set and"
+                      "SECBIT_NO_SETUID_FIXUP secure bit set.")
             return 1
 
         # Initialization (auto discovery Intel RDT features).

--- a/wca/runners/measurement.py
+++ b/wca/runners/measurement.py
@@ -153,8 +153,8 @@ class MeasurementRunner(Runner):
             log.error("Insufficient privileges! "
                       "Impossible to use perf_event_open/resctrl subsystems. "
                       "For unprivileged user it is needed to: "
-                      "adjust /proc/sys/kernel/perf_event_paranoid (set to -1); "
-                      "and has CAP_DAC_OVERRIDE and CAP_SETUID capabilities set and"
+                      "adjust /proc/sys/kernel/perf_event_paranoid (set to -1), "
+                      "has CAP_DAC_OVERRIDE and CAP_SETUID capabilities and"
                       "SECBIT_NO_SETUID_FIXUP secure bit set.")
             return 1
 

--- a/wca/security.py
+++ b/wca/security.py
@@ -65,7 +65,7 @@ class GettingCapabilitiesFailed(Exception):
     pass
 
 
-def are_privileges_sufficient(rdt_enabled) -> bool:
+def are_privileges_sufficient() -> bool:
     uid = os.geteuid()
     paranoid = _read_paranoid()
     capabilities = _get_capabilities()
@@ -74,10 +74,10 @@ def are_privileges_sufficient(rdt_enabled) -> bool:
     has_cap_dac_override = capabilities.effective & CAP_DAC_OVERRIDE == CAP_DAC_OVERRIDE
     has_cap_setuid = capabilities.effective & CAP_SETUID == CAP_SETUID
     log.debug("Determining privileges necessary to call run WCA - uid: {}, paranoid: {}, "
-              "CAP_DAC_OVERRIDE: {}".format(uid, paranoid, has_cap_dac_override))
+              "CAP_DAC_OVERRIDE: {}, CAP_SETUID: {}".format(uid, paranoid, has_cap_dac_override,
+                                                            has_cap_setuid))
     return uid == GLOBAL_ROOT_UID or \
-        paranoid <= ALLOW_CPU_EVENTS and (rdt_enabled is False or
-                                          (has_cap_dac_override and has_cap_setuid))
+        paranoid <= ALLOW_CPU_EVENTS and has_cap_dac_override and has_cap_setuid
 
 
 def _get_capabilities():


### PR DESCRIPTION
We missed that DAC_OVERRIDE and SETUID capabilities are required also for cpu type discovery,
so there was misleading privileges check error message that suggested some of privileges only required of RDT enabled.

Additionally SETUID and additional secure bit (docs update) is required for switching back to unprivileged user without loosing those two capabilities.