### PR TITLE
Fix problem with MB RDT allocations granularity.

### DIFF
--- a/tests/resctrl/test_resctrl_allocations.py
+++ b/tests/resctrl/test_resctrl_allocations.py
@@ -23,7 +23,7 @@ from wca.platforms import RDTInformation
 from wca.resctrl import ResGroup
 from wca.resctrl_allocations import RDTAllocationValue, RDTGroups, _parse_schemata_file_row, \
     _count_enabled_bits, check_cbm_mask, _is_rdt_suballocation_changed, _validate_domains, \
-    normalize_mb_value
+    _normalize_mb_value
 from tests.testing import create_open_mock, allocation_metric
 
 
@@ -279,7 +279,7 @@ def test_validate_domain_invalid(domains, platform_sockets, exception_match):
     ]
 )
 def test_normalize_mb_value(mb_value, mb_min_bandwidth, mb_bandwidth_gran, expected_mb_value):
-    assert expected_mb_value == normalize_mb_value(mb_value, mb_min_bandwidth, mb_bandwidth_gran)
+    assert expected_mb_value == _normalize_mb_value(mb_value, mb_min_bandwidth, mb_bandwidth_gran)
 
 
 @pytest.mark.parametrize(
@@ -290,4 +290,4 @@ def test_normalize_mb_value(mb_value, mb_min_bandwidth, mb_bandwidth_gran, expec
 )
 def test_invalid_allocations_normalize_mb_value(mb_value, mb_min_bandwidth, mb_bandwidth_gran):
     with pytest.raises(InvalidAllocations):
-        normalize_mb_value(mb_value, mb_min_bandwidth, mb_bandwidth_gran)
+        _normalize_mb_value(mb_value, mb_min_bandwidth, mb_bandwidth_gran)

--- a/tests/resctrl/test_resctrl_allocations.py
+++ b/tests/resctrl/test_resctrl_allocations.py
@@ -22,7 +22,8 @@ from wca.allocators import RDTAllocation
 from wca.platforms import RDTInformation
 from wca.resctrl import ResGroup
 from wca.resctrl_allocations import RDTAllocationValue, RDTGroups, _parse_schemata_file_row, \
-    _count_enabled_bits, check_cbm_mask, _is_rdt_suballocation_changed, _validate_domains
+    _count_enabled_bits, check_cbm_mask, _is_rdt_suballocation_changed, _validate_domains, \
+    normalize_mb_value
 from tests.testing import create_open_mock, allocation_metric
 
 
@@ -268,3 +269,25 @@ def test_validate_domain_ok(domains, platform_sockets):
 def test_validate_domain_invalid(domains, platform_sockets, exception_match):
     with pytest.raises(InvalidAllocations, match=exception_match):
         _validate_domains(domains, platform_sockets)
+
+
+@pytest.mark.parametrize(
+    'mb_value, mb_min_bandwidth, mb_bandwidth_gran, expected_mb_value', [
+        (10, 10, 10, 10),
+        (12, 10, 10, 20),
+        (17, 10, 10, 20),
+    ]
+)
+def test_normalize_mb_value(mb_value, mb_min_bandwidth, mb_bandwidth_gran, expected_mb_value):
+    assert expected_mb_value == normalize_mb_value(mb_value, mb_min_bandwidth, mb_bandwidth_gran)
+
+
+@pytest.mark.parametrize(
+    'mb_value, mb_min_bandwidth, mb_bandwidth_gran', [
+        (2, 10, 10),
+        (7, 10, 10),
+    ]
+)
+def test_invalid_allocations_normalize_mb_value(mb_value, mb_min_bandwidth, mb_bandwidth_gran):
+    with pytest.raises(InvalidAllocations):
+        normalize_mb_value(mb_value, mb_min_bandwidth, mb_bandwidth_gran)

--- a/tests/runners/test_runners_allocation_helpers.py
+++ b/tests/runners/test_runners_allocation_helpers.py
@@ -299,6 +299,7 @@ def test_rdt_initialize(rdt_max_values_mock, cleanup_resctrl_mock,
             spec=RDTInformation,
             cbm_mask='fff', min_cbm_bits='2',
             mb_min_bandwidth=10,
+            mb_bandwidth_gran=10,
             rdt_mb_control_enabled=platform_rdt_mb_control_enabled,
             rdt_cache_control_enabled=platform_rdt_cache_control_enabled)):
         assert runner._initialize_rdt() is not expected_error

--- a/wca/platforms.py
+++ b/wca/platforms.py
@@ -83,7 +83,7 @@ class RDTInformation:
 
     # MB control read-only parameters.
     mb_bandwidth_gran: Optional[int]  # based on /sys/fs/resctrl/info/MB/bandwidth_gran
-    mb_min_bandwidth: Optional[int]   # based on /sys/fs/resctrl/info/MB/bandwidth_gran
+    mb_min_bandwidth: Optional[int]   # based on /sys/fs/resctrl/info/MB/min_bandwidth
 
     def is_control_enabled(self):
         return self.rdt_mb_control_enabled or self.rdt_cache_control_enabled

--- a/wca/resctrl_allocations.py
+++ b/wca/resctrl_allocations.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
+import math
 from typing import Callable, List, Optional, Dict
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
 from wca.allocations import AllocationValue, InvalidAllocations, LabelsUpdater
 from wca.allocators import RDTAllocation
@@ -248,9 +249,13 @@ class RDTAllocationValue(AllocationValue):
             if not self.rdt_information.rdt_mb_control_enabled:
                 raise InvalidAllocations('Allocator requested RDT MB allocation but '
                                          'RDT memory bandwidth is not enabled!')
-            validate_mb_string(self.rdt_allocation.mb,
-                               self.platform_sockets,
-                               self.rdt_information.mb_min_bandwidth)
+            normalized_mb_string = normalize_mb_string(
+                                        self.rdt_allocation.mb,
+                                        self.platform_sockets,
+                                        self.rdt_information.mb_min_bandwidth,
+                                        self.rdt_information.mb_bandwidth_gran)
+
+            replace(self.rdt_allocation, mb=normalized_mb_string)
 
         self.rdt_groups.validate(self)
 
@@ -387,8 +392,9 @@ def validate_l3_string(l3, platform_sockets, rdt_cbm_mask, rdt_min_cbm_bits):
                        rdt_min_cbm_bits)
 
 
-def validate_mb_string(mb, platform_sockets, mb_min_bandwidth):
+def normalize_mb_string(mb, platform_sockets, mb_min_bandwidth, mb_bandwidth_gran) -> str:
     assert mb_min_bandwidth is not None
+    assert mb_bandwidth_gran is not None
     if not mb.startswith('MB:'):
         raise InvalidAllocations(
             'mb resources setting should start with "MB:" prefix (got %r)' % mb)
@@ -396,20 +402,32 @@ def validate_mb_string(mb, platform_sockets, mb_min_bandwidth):
     domains = _parse_schemata_file_row(mb)
     _validate_domains(domains, platform_sockets)
 
-    for mb_value in domains.values():
-        check_mb_value(mb_value, mb_min_bandwidth)
+    normalized_mb_string = 'MB:'
+    for domain in domains:
+        try:
+            mb_value = int(domains[domain])
+        except ValueError:
+            raise InvalidAllocations("{} is not integer format".format(mb_value))
+
+        normalized_mb_value = normalize_mb_value(mb_value, mb_min_bandwidth, mb_bandwidth_gran)
+        normalized_mb_string += '{}={};'.format(domain, normalized_mb_value)
+
+    normalized_mb_string = normalized_mb_string[:-1]
+
+    return normalized_mb_string
 
 
-def check_mb_value(mb_value: str, mb_min_bandwidth):
-    try:
-        mb_value = int(mb_value)
-    except ValueError:
-        raise InvalidAllocations("{} is not integer format".format(mb_value))
-
+def normalize_mb_value(mb_value: int, mb_min_bandwidth: int, mb_bandwidth_gran: int) -> int:
+    """Ceil mb value to match granulation."""
     if mb_value < mb_min_bandwidth:
         raise InvalidAllocations(
                 "mb allocation smaller than minimum value {}"
                 .format(str(mb_min_bandwidth)))
+    try:
+        return math.ceil(mb_value/mb_bandwidth_gran) * mb_bandwidth_gran
+    # If mb_bandwidth_gran is 0 do nothing.
+    except ZeroDivisionError:
+        return mb_value
 
 
 def _count_enabled_bits(hexstr: str) -> int:

--- a/wca/resctrl_allocations.py
+++ b/wca/resctrl_allocations.py
@@ -392,9 +392,11 @@ def validate_l3_string(l3, platform_sockets, rdt_cbm_mask, rdt_min_cbm_bits):
                        rdt_min_cbm_bits)
 
 
-def normalize_mb_string(mb, platform_sockets, mb_min_bandwidth, mb_bandwidth_gran) -> str:
+def normalize_mb_string(mb: str, platform_sockets: int, mb_min_bandwidth: int,
+                        mb_bandwidth_gran: int) -> str:
     assert mb_min_bandwidth is not None
     assert mb_bandwidth_gran is not None
+
     if not mb.startswith('MB:'):
         raise InvalidAllocations(
             'mb resources setting should start with "MB:" prefix (got %r)' % mb)
@@ -409,7 +411,7 @@ def normalize_mb_string(mb, platform_sockets, mb_min_bandwidth, mb_bandwidth_gra
         except ValueError:
             raise InvalidAllocations("{} is not integer format".format(domains[domain]))
 
-        normalized_mb_value = normalize_mb_value(mb_value, mb_min_bandwidth, mb_bandwidth_gran)
+        normalized_mb_value = _normalize_mb_value(mb_value, mb_min_bandwidth, mb_bandwidth_gran)
         normalized_mb_string += '{}={};'.format(domain, normalized_mb_value)
 
     normalized_mb_string = normalized_mb_string[:-1]
@@ -417,16 +419,16 @@ def normalize_mb_string(mb, platform_sockets, mb_min_bandwidth, mb_bandwidth_gra
     return normalized_mb_string
 
 
-def normalize_mb_value(mb_value: int, mb_min_bandwidth: int, mb_bandwidth_gran: int) -> int:
+def _normalize_mb_value(mb_value: int, mb_min_bandwidth: int, mb_bandwidth_gran: int) -> int:
     """Ceil mb value to match granulation."""
     if mb_value < mb_min_bandwidth:
         raise InvalidAllocations(
                 "mb allocation smaller than minimum value {}"
                 .format(str(mb_min_bandwidth)))
-    try:
+
+    if mb_bandwidth_gran > 0:
         return math.ceil(mb_value/mb_bandwidth_gran) * mb_bandwidth_gran
-    # If mb_bandwidth_gran is 0 do nothing.
-    except ZeroDivisionError:
+    else:
         return mb_value
 
 

--- a/wca/resctrl_allocations.py
+++ b/wca/resctrl_allocations.py
@@ -407,7 +407,7 @@ def normalize_mb_string(mb, platform_sockets, mb_min_bandwidth, mb_bandwidth_gra
         try:
             mb_value = int(domains[domain])
         except ValueError:
-            raise InvalidAllocations("{} is not integer format".format(mb_value))
+            raise InvalidAllocations("{} is not integer format".format(domains[domain]))
 
         normalized_mb_value = normalize_mb_value(mb_value, mb_min_bandwidth, mb_bandwidth_gran)
         normalized_mb_string += '{}={};'.format(domain, normalized_mb_value)


### PR DESCRIPTION
> The allocated b/w percentage is rounded off to the next control step available on the hardware. The
available bandwidth control steps are: min_bandwidth + N * bandwidth_gran.

Source: `https://www.kernel.org/doc/Documentation/x86/intel_rdt_ui.txt`