### PR TITLE
Fix `PEX_INHERIT_PATH` flag for integration tests.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,7 +52,7 @@ pipeline {
                         sh '''
 			sudo chmod 700 $(pwd)/tests/tester/configs/tester_example.yaml
                         sudo bash -c "
-                        PEX_INHERIT_PATH=fallback PYTHONPATH="$(pwd)/tests/tester" dist/wca.pex -c $(pwd)/tests/tester/configs/tester_example.yaml \
+                        PEX_INHERIT_PATH=fallback PYTHONPATH="$(pwd):$(pwd)/tests/tester" dist/wca.pex -c $(pwd)/tests/tester/configs/tester_example.yaml \
                         -r tester:Tester -r tester:MetricCheck -r tester:FileCheck \
                         --log=debug --root
                         "

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,7 +52,7 @@ pipeline {
                         sh '''
 			sudo chmod 700 $(pwd)/tests/tester/configs/tester_example.yaml
                         sudo bash -c "
-                        PEX_INHERIT_PATH=prefer PYTHONPATH="$(pwd):$(pwd)/tests/tester" dist/wca.pex -c $(pwd)/tests/tester/configs/tester_example.yaml \
+                        PEX_INHERIT_PATH=fallback PYTHONPATH="$(pwd)/tests/tester" dist/wca.pex -c $(pwd)/tests/tester/configs/tester_example.yaml \
                         -r tester:Tester -r tester:MetricCheck -r tester:FileCheck \
                         --log=debug --root
                         "

--- a/docs/extending.rst
+++ b/docs/extending.rst
@@ -102,7 +102,7 @@ and then with WCA started like this
 
 .. code-block:: shell
 
-    PYTHONPATH=example PEX_INERHITPATH=1 ./dist/wca.pex -c $PWD/configs/extending/hello_world.yaml -r hello_world_runner:HelloWorldRunner
+    PYTHONPATH=$PWD/example PEX_INHERIT_PATH=fallback ./dist/wca.pex -c $PWD/configs/extending/hello_world.yaml -r hello_world_runner:HelloWorldRunner
 
 :Tip: You can just copy-paste this command, all required example files are already in project, but you have to build pex file first with ``make``.
 


### PR DESCRIPTION
User `PYTHONPATH` should not be prefered in pex file.