### PR TITLE
Fix build cgroup path for systemd in Kubernetes

### DIFF
--- a/tests/e2e/demo_scenarios/common/wca_config_mesos.yaml
+++ b/tests/e2e/demo_scenarios/common/wca_config_mesos.yaml
@@ -1,7 +1,7 @@
 runner: !AllocationRunner
   rdt_enabled: True
   node: !MesosNode
-    mesos_agent_endpoint: "http://127.0.0.1:5051"
+    mesos_agent_endpoint: "http://100.64.176.14:5051"
   action_delay: 10.
   metrics_storage: !KafkaStorage
     brokers_ips: ['100.64.176.12:9092']

--- a/tests/test_kubernetes.py
+++ b/tests/test_kubernetes.py
@@ -131,20 +131,40 @@ def test_calculate_resources_multiple_containers():
 
 
 _POD_ID = '12345-67890'
+_STATIC_POD_ID = '09876-54321'
+_CUTTED_STATIC_POD_ID = '0987654321'
+_CONTAINER_ID = '123456'
 
 
 @pytest.mark.parametrize('qos, expected_cgroup_path', (
-        ('burstable',  '/kubepods.slice/kubepods-burstable.slice/'
-                       'kubepods-burstable-pod12345-67890.slice'),
+        ('burstable', '/kubepods.slice/kubepods-burstable.slice/'
+                      'kubepods-burstable-pod12345_67890.slice'),
         ('guaranteed', '/kubepods.slice/kubepods-guaranteed.slice/'
-                       'kubepods-guaranteed-pod12345-67890.slice'),
+                       'kubepods-guaranteed-pod12345_67890.slice'),
         ('besteffort', '/kubepods.slice/kubepods-besteffort.slice/'
-                       'kubepods-besteffort-pod12345-67890.slice'),
-    )
+                       'kubepods-besteffort-pod12345_67890.slice'),
 )
+                         )
 def test_find_cgroup_path_for_pod_systemd(qos, expected_cgroup_path):
     assert expected_cgroup_path == _build_cgroup_path(cgroup_driver='systemd',
                                                       qos=qos, pod_id=_POD_ID)
+
+@pytest.mark.parametrize('qos, expected_cgroup_path', (
+        ('burstable', '/kubepods.slice/kubepods-burstable.slice/'
+                      'kubepods-burstable-pod12345_67890.slice/'
+                      'docker-123456.scope'),
+        ('guaranteed', '/kubepods.slice/kubepods-guaranteed.slice/'
+                       'kubepods-guaranteed-pod12345_67890.slice/'
+                       'docker-123456.scope'),
+        ('besteffort', '/kubepods.slice/kubepods-besteffort.slice/'
+                       'kubepods-besteffort-pod12345_67890.slice/'
+                       'docker-123456.scope'),
+)
+                         )
+def test_find_cgroup_path_for_pod_systemd_with_container_id(qos, expected_cgroup_path):
+    assert expected_cgroup_path == _build_cgroup_path(cgroup_driver='systemd',
+                                                      qos=qos, pod_id=_POD_ID,
+                                                      container_id=_CONTAINER_ID)
 
 
 @pytest.mark.parametrize('qos, expected_cgroup_path', (

--- a/wca/kubernetes.py
+++ b/wca/kubernetes.py
@@ -184,6 +184,9 @@ def _build_cgroup_path(cgroup_driver, qos, pod_id, container_id=''):
     """If cgroup for pod needed set container_id to empty string."""
     result: str = ""
     if cgroup_driver == CgroupDriverType.SYSTEMD:
+        pod_id = pod_id.replace("-", "_")
+        if container_id != "":
+            container_id = "docker-" + container_id + ".scope"
         result = os.path.join('/kubepods.slice',
                               'kubepods-{}.slice'.format(qos),
                               'kubepods-{}-pod{}.slice'.format(qos, pod_id),


### PR DESCRIPTION
Cgroup path for cgroup driver systemd for Kubernetes was built in incorrect way. I've added fix and tests. The changes was tested on Kubernetes 1.15 and 1.16.