### PR TITLE
Check if swap is disabled before using migrate_pages allocation.

### DIFF
--- a/tests/test_cgroups_allocations.py
+++ b/tests/test_cgroups_allocations.py
@@ -12,15 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
+
 from unittest.mock import patch, call, Mock
 
 from tests.testing import allocation_metric
 from wca.allocators import AllocationConfiguration, AllocationType
-from wca.cgroups_allocations import QuotaAllocationValue, SharesAllocationValue, \
-    CPUSetCPUSAllocationValue, CPUSetMEMSAllocationValue
+from wca.cgroups_allocations import (QuotaAllocationValue, SharesAllocationValue,
+                                     CPUSetCPUSAllocationValue, CPUSetMEMSAllocationValue,
+                                     MigratePagesAllocationValue)
 from wca.containers import Container
 from wca.metrics import Metric, MetricType
-from wca.platforms import Platform, RDTInformation
+from wca.platforms import Platform, RDTInformation, SwapEnabled
 
 
 @patch('wca.perf.PerfCounters')
@@ -81,3 +84,26 @@ def test_cgroup_allocations(Cgroup_mock, PerfCounters_mock):
         call().set_cpuset_cpus({0, 1, 2, 4, 6, 7, 8}),
         call().set_cpuset_mems({0, 1})
     ], True)
+
+
+@patch('wca.platforms.read_proc_meminfo',
+       return_value='SwapCached: 3000kB \nSwapTotal: 123000kB\nSwapFree: 20000kB')
+@patch('wca.cgroups.Cgroup')
+def test_migrate_pages_raise_exception_when_swap_is_enabled(*mocks):
+    rdt_information = RDTInformation(True, True, True, True, '0', '0', 0, 0, 0)
+
+    platform_mock = Mock(
+        spec=Platform,
+        cpus=10,
+        sockets=1,
+        rdt_information=rdt_information,
+        node_cpus={0: [0, 1], 1: [2, 3]},
+    )
+
+    foo_container = Container(
+        '/somepath', platform=platform_mock)
+
+    migrate_pages = MigratePagesAllocationValue(0, foo_container, dict(foo='bar'))
+
+    with pytest.raises(SwapEnabled):
+        migrate_pages.perform_allocations()

--- a/tests/test_cgroups_allocations.py
+++ b/tests/test_cgroups_allocations.py
@@ -99,7 +99,8 @@ def test_migrate_pages_raise_exception_when_swap_is_enabled(*mocks):
         sockets=1,
         rdt_information=rdt_information,
         node_cpus={0: [0, 1], 1: [2, 3]},
-        numa_nodes=2
+        numa_nodes=2,
+        swap_enabled=True
     )
 
     foo_container = Container(

--- a/tests/test_platforms.py
+++ b/tests/test_platforms.py
@@ -171,7 +171,8 @@ def test_collect_platform_information(*mocks):
                       MetricName.MEM_USAGE: 1337,
                       MetricName.MEM_NUMA_FREE: {0: 1},
                       MetricName.MEM_NUMA_USED: {0: 2}},
-        static_information={}
+        static_information={},
+        swap_enabled=False
     )
 
     print(got_metrics)

--- a/tests/testing.py
+++ b/tests/testing.py
@@ -185,7 +185,8 @@ def container(cgroup_path, subcgroups_paths=None, with_config=False,
                 node_cpus={0: {0, 1}},
                 node_distances={0: [10]},
                 measurements={},
-                static_information={}
+                static_information={},
+                swap_enabled=False
             )
             return ContainerSet(
                 cgroup_path=cgroup_path,
@@ -210,7 +211,8 @@ def container(cgroup_path, subcgroups_paths=None, with_config=False,
                 node_cpus={0: {0, 1}},
                 node_distances={0: [10]},
                 measurements={},
-                static_information={}
+                static_information={},
+                swap_enabled=False
             )
             return Container(
                 cgroup_path=cgroup_path,

--- a/wca/cgroups_allocations.py
+++ b/wca/cgroups_allocations.py
@@ -22,7 +22,7 @@ from wca.allocators import AllocationType
 from wca.cgroups import QUOTA_NORMALIZED_MAX
 from wca.containers import ContainerInterface
 from wca.metrics import Metric, MetricType
-from wca.platforms import decode_listformat, is_swap_enabled
+from wca.platforms import decode_listformat
 from wca.logger import TRACE
 
 log = logging.getLogger(__name__)
@@ -202,7 +202,7 @@ class MigratePagesAllocationValue(BoxedNumeric):
 
     def validate(self):
         super().validate()
-        if is_swap_enabled():
+        if self.platform.swap_enabled:
             raise InvalidAllocations(
                     "Swap should be disabled due to possibility of OOM killer occurrence!")
 

--- a/wca/cgroups_allocations.py
+++ b/wca/cgroups_allocations.py
@@ -22,7 +22,7 @@ from wca.allocators import AllocationType
 from wca.cgroups import QUOTA_NORMALIZED_MAX
 from wca.containers import ContainerInterface
 from wca.metrics import Metric, MetricType
-from wca.platforms import decode_listformat
+from wca.platforms import decode_listformat, is_swap_enabled, SwapEnabled
 from wca.logger import TRACE
 
 log = logging.getLogger(__name__)
@@ -194,6 +194,10 @@ class MigratePagesAllocationValue(BoxedNumeric):
         return metrics
 
     def perform_allocations(self):
+        if is_swap_enabled():
+            raise SwapEnabled(
+                    "Swap should be disabled due to possibility of OOM killer occurrence!")
+
         _migrate_pages(
             self.container.get_pids(include_threads=False),
             self.value,

--- a/wca/platforms.py
+++ b/wca/platforms.py
@@ -677,3 +677,15 @@ def encode_listformat(ints: Set[int]) -> str:
     """
     assert all(isinstance(i, int) for i in ints), 'simple type check'
     return ','.join(map(str, sorted(ints)))
+
+
+class SwapEnabled(Exception):
+    pass
+
+
+def is_swap_enabled() -> bool:
+    mem_info = read_proc_meminfo()
+    for line in mem_info.split('\n'):
+        if line.startswith("Swap"):
+            return True
+    return False

--- a/wca/platforms.py
+++ b/wca/platforms.py
@@ -170,6 +170,8 @@ class Platform:
 
     static_information: Optional[Dict]
 
+    swap_enabled: bool
+
 
 class MissingPlatformStaticInformation(Exception):
     pass
@@ -636,6 +638,7 @@ def collect_platform_information(rdt_enabled: bool = True,
         node_distances=parse_node_distances(),
         measurements=platform_measurements,
         static_information=platform_static_information,
+        swap_enabled=is_swap_enabled()
     )
     assert len(platform_measurements[MetricName.CPU_USAGE_PER_CPU]) == platform.cpus, \
         "Inconsistency in cpu data returned by kernel"
@@ -682,6 +685,9 @@ def encode_listformat(ints: Set[int]) -> str:
 def is_swap_enabled() -> bool:
     mem_info = read_proc_meminfo()
     for line in mem_info.split('\n'):
-        if line.startswith("Swap"):
+        if line.startswith("SwapTotal"):
+            _, value = line.split(' ')
+            if value.startswith('0'):
+                return False
             return True
     return False

--- a/wca/platforms.py
+++ b/wca/platforms.py
@@ -679,10 +679,6 @@ def encode_listformat(ints: Set[int]) -> str:
     return ','.join(map(str, sorted(ints)))
 
 
-class SwapEnabled(Exception):
-    pass
-
-
 def is_swap_enabled() -> bool:
     mem_info = read_proc_meminfo()
     for line in mem_info.split('\n'):

--- a/wca/platforms.py
+++ b/wca/platforms.py
@@ -686,7 +686,7 @@ def is_swap_enabled() -> bool:
     mem_info = read_proc_meminfo()
     for line in mem_info.split('\n'):
         if line.startswith("SwapTotal"):
-            _, value = line.split(' ')
+            value = line.split(' ')[1]
             if value.startswith('0'):
                 return False
             return True


### PR DESCRIPTION
It causes OOM kills if there is not enough memory.