### PR TITLE
Tag images create by WCA with branch name and check that there is enough available PMU counters.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -238,7 +238,7 @@ pipeline {
                         withCredentials([file(credentialsId: 'specjbb', variable: 'SPECJBB_TAR')]) {
                             sh '''
                             IMAGE_NAME=${DOCKER_REPOSITORY_URL}/wca/specjbb:${GIT_COMMIT}
-                            BRANCH_IMAGE_NAME=${DOCKER_REPOSITORY_URL}/wca/specjbbj:${GIT_BRANCH}
+                            BRANCH_IMAGE_NAME=${DOCKER_REPOSITORY_URL}/wca/specjbb:${GIT_BRANCH}
                             IMAGE_DIR=${WORKSPACE}/examples/workloads/specjbb
                             cp ${SPECJBB_TAR} ${IMAGE_DIR}
                             tar -xC ${IMAGE_DIR} -f ${IMAGE_DIR}/specjbb.tar.bz2

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -189,7 +189,7 @@ pipeline {
                     steps {
                     sh '''
                     IMAGE_NAME=${DOCKER_REPOSITORY_URL}/wca/cassandra_stress:${GIT_COMMIT}
-                    BRANCH_IMAGE_NAME=${DOCKER_REPOSITORY_URL}/wca/cassandra_stress':${GIT_BRANCH}
+                    BRANCH_IMAGE_NAME=${DOCKER_REPOSITORY_URL}/wca/cassandra_stress:${GIT_BRANCH}
                     IMAGE_DIR=${WORKSPACE}/examples/workloads/cassandra_stress
                     cp -r dist ${IMAGE_DIR}
                     docker build -t ${IMAGE_NAME} -f ${IMAGE_DIR}/Dockerfile ${IMAGE_DIR}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -94,9 +94,12 @@ pipeline {
                     steps {
                     sh '''
                     IMAGE_NAME=${DOCKER_REPOSITORY_URL}/wca/redis:${GIT_COMMIT}
+                    BRANCH_IMAGE_NAME=${DOCKER_REPOSITORY_URL}/wca/redis:${GIT_BRANCH}
                     IMAGE_DIR=${WORKSPACE}/examples/workloads/redis
                     docker build -t ${IMAGE_NAME} -f ${IMAGE_DIR}/Dockerfile ${IMAGE_DIR}
                     docker push ${IMAGE_NAME}
+                    docker tag ${IMAGE_NAME} ${BRANCH_IMAGE_NAME}
+                    docker push ${BRANCH_IMAGE_NAME}
                     '''
                     }
                 }
@@ -106,10 +109,13 @@ pipeline {
                     steps {
                     sh '''
                     IMAGE_NAME=${DOCKER_REPOSITORY_URL}/wca/memtier_benchmark:${GIT_COMMIT}
+                    BRANCH_IMAGE_NAME=${DOCKER_REPOSITORY_URL}/wca/memtier_benchmark:${GIT_BRANCH}
                     IMAGE_DIR=${WORKSPACE}/examples/workloads/memtier_benchmark
                     cp -r dist ${IMAGE_DIR}
                     docker build -t ${IMAGE_NAME} -f ${IMAGE_DIR}/Dockerfile ${IMAGE_DIR}
                     docker push ${IMAGE_NAME}
+                    docker tag ${IMAGE_NAME} ${BRANCH_IMAGE_NAME}
+                    docker push ${BRANCH_IMAGE_NAME}
                     '''
                     }
                 }
@@ -119,10 +125,13 @@ pipeline {
                     steps {
                     sh '''
                     IMAGE_NAME=${DOCKER_REPOSITORY_URL}/wca/stress_ng:${GIT_COMMIT}
+                    BRANCH_IMAGE_NAME=${DOCKER_REPOSITORY_URL}/wca/stress_ng:${GIT_BRANCH}
                     IMAGE_DIR=${WORKSPACE}/examples/workloads/stress_ng
                     cp -r dist ${IMAGE_DIR}
                     docker build -t ${IMAGE_NAME} -f ${IMAGE_DIR}/Dockerfile ${IMAGE_DIR}
                     docker push ${IMAGE_NAME}
+                    docker tag ${IMAGE_NAME} ${BRANCH_IMAGE_NAME}
+                    docker push ${BRANCH_IMAGE_NAME}
                     '''
                     }
                 }
@@ -132,10 +141,13 @@ pipeline {
                     steps {
                     sh '''
                     IMAGE_NAME=${DOCKER_REPOSITORY_URL}/wca/rpc_perf:${GIT_COMMIT}
+                    BRANCH_IMAGE_NAME=${DOCKER_REPOSITORY_URL}/wca/rpc_perf:${GIT_BRANCH}
                     IMAGE_DIR=${WORKSPACE}/examples/workloads/rpc_perf
                     cp -r dist ${IMAGE_DIR}
                     docker build -t ${IMAGE_NAME} -f ${IMAGE_DIR}/Dockerfile ${IMAGE_DIR}
                     docker push ${IMAGE_NAME}
+                    docker tag ${IMAGE_NAME} ${BRANCH_IMAGE_NAME}
+                    docker push ${BRANCH_IMAGE_NAME}
                     '''
                     }
                 }
@@ -145,10 +157,13 @@ pipeline {
                     steps {
                     sh '''
                     IMAGE_NAME=${DOCKER_REPOSITORY_URL}/wca/twemcache:${GIT_COMMIT}
+                    BRANCH_IMAGE_NAME=${DOCKER_REPOSITORY_URL}/wca/twemcache:${GIT_BRANCH}
                     IMAGE_DIR=${WORKSPACE}/examples/workloads/twemcache
                     cp -r dist ${IMAGE_DIR}
                     docker build -t ${IMAGE_NAME} -f ${IMAGE_DIR}/Dockerfile ${IMAGE_DIR}
                     docker push ${IMAGE_NAME}
+                    docker tag ${IMAGE_NAME} ${BRANCH_IMAGE_NAME}
+                    docker push ${BRANCH_IMAGE_NAME}
                     '''
                     }
                 }
@@ -158,10 +173,13 @@ pipeline {
                     steps {
                     sh '''
                     IMAGE_NAME=${DOCKER_REPOSITORY_URL}/wca/ycsb:${GIT_COMMIT}
+                    BRANCH_IMAGE_NAME=${DOCKER_REPOSITORY_URL}/wca/ycsb:${GIT_BRANCH}
                     IMAGE_DIR=${WORKSPACE}/examples/workloads/ycsb
                     cp -r dist ${IMAGE_DIR}
                     docker build -t ${IMAGE_NAME} -f ${IMAGE_DIR}/Dockerfile ${IMAGE_DIR}
                     docker push ${IMAGE_NAME}
+                    docker tag ${IMAGE_NAME} ${BRANCH_IMAGE_NAME}
+                    docker push ${BRANCH_IMAGE_NAME}
                     '''
                     }
                 }
@@ -171,10 +189,13 @@ pipeline {
                     steps {
                     sh '''
                     IMAGE_NAME=${DOCKER_REPOSITORY_URL}/wca/cassandra_stress:${GIT_COMMIT}
+                    BRANCH_IMAGE_NAME=${DOCKER_REPOSITORY_URL}/wca/cassandra_stress':${GIT_BRANCH}
                     IMAGE_DIR=${WORKSPACE}/examples/workloads/cassandra_stress
                     cp -r dist ${IMAGE_DIR}
                     docker build -t ${IMAGE_NAME} -f ${IMAGE_DIR}/Dockerfile ${IMAGE_DIR}
                     docker push ${IMAGE_NAME}
+                    docker tag ${IMAGE_NAME} ${BRANCH_IMAGE_NAME}
+                    docker push ${BRANCH_IMAGE_NAME}
                     '''
                     }
                 }
@@ -184,10 +205,13 @@ pipeline {
                     steps {
                     sh '''
                     IMAGE_NAME=${DOCKER_REPOSITORY_URL}/wca/sysbench:${GIT_COMMIT}
+                    BRANCH_IMAGE_NAME=${DOCKER_REPOSITORY_URL}/wca/sysbench:${GIT_BRANCH}
                     IMAGE_DIR=${WORKSPACE}/examples/workloads/sysbench
                     cp -r dist ${IMAGE_DIR}
                     docker build -t ${IMAGE_NAME} -f ${IMAGE_DIR}/Dockerfile ${IMAGE_DIR}
                     docker push ${IMAGE_NAME}
+                    docker tag ${IMAGE_NAME} ${BRANCH_IMAGE_NAME}
+                    docker push ${BRANCH_IMAGE_NAME}
                     '''
                     }
                 }
@@ -197,10 +221,13 @@ pipeline {
                     steps {
                     sh '''
                     IMAGE_NAME=${DOCKER_REPOSITORY_URL}/wca/mutilate:${GIT_COMMIT}
+                    BRANCH_IMAGE_NAME=${DOCKER_REPOSITORY_URL}/wca/mutilate:${GIT_BRANCH}
                     IMAGE_DIR=${WORKSPACE}/examples/workloads/mutilate
                     cp -r dist ${IMAGE_DIR}
                     docker build -t ${IMAGE_NAME} -f ${IMAGE_DIR}/Dockerfile ${IMAGE_DIR}
                     docker push ${IMAGE_NAME}
+                    docker tag ${IMAGE_NAME} ${BRANCH_IMAGE_NAME}
+                    docker push ${BRANCH_IMAGE_NAME}
                     '''
                     }
                 }
@@ -211,12 +238,15 @@ pipeline {
                         withCredentials([file(credentialsId: 'specjbb', variable: 'SPECJBB_TAR')]) {
                             sh '''
                             IMAGE_NAME=${DOCKER_REPOSITORY_URL}/wca/specjbb:${GIT_COMMIT}
+                            BRANCH_IMAGE_NAME=${DOCKER_REPOSITORY_URL}/wca/specjbbj:${GIT_BRANCH}
                             IMAGE_DIR=${WORKSPACE}/examples/workloads/specjbb
                             cp ${SPECJBB_TAR} ${IMAGE_DIR}
                             tar -xC ${IMAGE_DIR} -f ${IMAGE_DIR}/specjbb.tar.bz2
                             cp -r dist ${IMAGE_DIR}
                             docker build -t ${IMAGE_NAME} -f ${IMAGE_DIR}/Dockerfile ${IMAGE_DIR}
                             docker push ${IMAGE_NAME}
+                            docker tag ${IMAGE_NAME} ${BRANCH_IMAGE_NAME}
+                            docker push ${BRANCH_IMAGE_NAME}
                             '''
                         }
                     }

--- a/tests/test_perf.py
+++ b/tests/test_perf.py
@@ -24,9 +24,9 @@ from wca import metrics
 from wca import perf
 from wca import perf_const as pc
 from wca.metrics import MetricName
-from wca.perf import _parse_raw_event_name, _get_event_config, PerfCgroupDerivedMetricsGenerator
+from wca.perf import _parse_raw_event_name, _get_event_config, PerfCgroupDerivedMetricsGenerator, \
+    filter_out_event_names_for_cpu, check_out_perf_event_names
 from wca.platforms import CPUCodeName, Platform
-from wca.runners.measurement import _filter_out_event_names_for_cpu
 
 
 @pytest.mark.parametrize("raw_value,time_enabled,time_running,expected_value,expected_factor", [
@@ -410,7 +410,7 @@ def test_derived_metrics_flat():
       MetricName.TASK_OFFCORE_REQUESTS_OUTSTANDING_L3_MISS_DEMAND_DATA_RD, 'task_instructions']),
 ])
 def test_parse_event_names(event_names, cpu_codename, expected):
-    parsed_event_names = _filter_out_event_names_for_cpu(event_names, cpu_codename)
+    parsed_event_names = filter_out_event_names_for_cpu(event_names, cpu_codename)
     assert set(parsed_event_names) == set(expected)
 
 
@@ -428,4 +428,24 @@ def test_parse_event_names(event_names, cpu_codename, expected):
      CPUCodeName.SKYLAKE)])
 def test_exception_parse_event_names(event_names, cpu_codename):
     with pytest.raises(Exception):
-        _filter_out_event_names_for_cpu(event_names, cpu_codename)
+        filter_out_event_names_for_cpu(event_names, cpu_codename)
+
+
+@pytest.mark.parametrize('event_names, cpus, cores, expected', [
+    # for HT enabled 5 is too much
+    (['e1', 'e2', 'e3', 'e4', 'e5'], 8, 4, False),
+    # for HT disabled 8 is ok
+    (['e1', 'e2', 'e3', 'e4', 'e5', 'e6', 'e7', 'e8'], 16, 16, True),
+    # for HT disabled 9 is too much
+    (['e1', 'e2', 'e3', 'e4', 'e5', 'e6', 'e7', 'e8', 'e9'], 16, 16, False),
+    # fixed counters are not taken into consideration
+    (['task_cycles', 'task_instructions', 'e1', 'e2', 'e3', 'e4'], 4, 8, True),
+    # fixed counters are not taken into consideration
+    (['task_cycles', 'task_instructions', 'e1', 'e2', 'e3', 'e4',
+      'e5', 'e6', 'e7', 'e8'], 8, 8, True),
+    # HD=disabled fixed counters are not taken into consideration
+    (['task_cycles', 'task_instructions', 'e1', 'e2', 'e3', 'e4', 'e5'], 8, 4, False),
+])
+def test_check_out_perf_event_names(event_names, cpus, cores, exectedc):
+    got = check_out_perf_event_names(event_names, cpus, cores)
+    assert exectedc == got

--- a/tests/test_perf.py
+++ b/tests/test_perf.py
@@ -25,7 +25,7 @@ from wca import perf
 from wca import perf_const as pc
 from wca.metrics import MetricName
 from wca.perf import _parse_raw_event_name, _get_event_config, PerfCgroupDerivedMetricsGenerator, \
-    filter_out_event_names_for_cpu, check_out_perf_event_names
+    filter_out_event_names_for_cpu, check_perf_event_count_limit
 from wca.platforms import CPUCodeName, Platform
 
 
@@ -446,6 +446,6 @@ def test_exception_parse_event_names(event_names, cpu_codename):
     # HD=disabled fixed counters are not taken into consideration
     (['task_cycles', 'task_instructions', 'e1', 'e2', 'e3', 'e4', 'e5'], 8, 4, False),
 ])
-def test_check_out_perf_event_names(event_names, cpus, cores, exectedc):
-    got = check_out_perf_event_names(event_names, cpus, cores)
-    assert exectedc == got
+def test_check_out_perf_event_names(event_names, cpus, cores, expected):
+    got = check_perf_event_count_limit(event_names, cpus, cores)
+    assert expected == got

--- a/wca/perf.py
+++ b/wca/perf.py
@@ -441,9 +441,9 @@ class PerfCgroupDerivedMetricsGenerator(BaseDerivedMetricsGenerator):
                 measurements[MetricName.TASK_CACHE_HIT_RATIO] = cache_hit_ratio
 
 
-def check_out_perf_event_names(
+def check_perf_event_count_limit(
         event_names: List[str], platform_cpus: int, platform_cores: int) -> bool:
-    """Check there is enough perf event programable coutners to schedule all of them
+    """Check there is enough perf event programmable counters to schedule all of them
     at the same time (implementation we used in perf.py)
 
     Note: Excludes fixed counters from check.

--- a/wca/perf.py
+++ b/wca/perf.py
@@ -439,3 +439,56 @@ class PerfCgroupDerivedMetricsGenerator(BaseDerivedMetricsGenerator):
                 cache_hit_ratio = _operation_on_leveled_dicts(cache_hits_count, cache_ref_delta,
                                                               truediv, max_depth)
                 measurements[MetricName.TASK_CACHE_HIT_RATIO] = cache_hit_ratio
+
+
+def check_out_perf_event_names(
+        event_names: List[str], platform_cpus: int, platform_cores: int) -> bool:
+    """Check there is enough perf event programable coutners to schedule all of them
+    at the same time (implementation we used in perf.py)
+
+    Note: Excludes fixed counters from check.
+
+    8 with no HT and 4 for HT excluding fixed counters and check if there is enough
+    counters to measure generic events.
+    Validated for BDX, SKX and CLX (cpuid -1 -l 0xa)
+
+    return False and logs errors if there is a problem.
+    else return True
+    """
+    number_of_events = len([e for e in event_names if e not in
+                            [MetricName.TASK_INSTRUCTIONS, MetricName.TASK_CYCLES]])
+    ht_enabled = (platform_cpus != platform_cores)
+    max_number_of_events = 4 if ht_enabled else 8
+    log.debug('HT state: %s, assuming number of available HW counters: %i (required=%i)',
+              ht_enabled, max_number_of_events, number_of_events)
+    if number_of_events > max_number_of_events:
+        log.error('Not enough hardware counters to measure %i programmable events '
+                  '(available is %s!)', number_of_events, max_number_of_events)
+        return False
+    # Everything is ok
+    return True
+
+
+def filter_out_event_names_for_cpu(
+        event_names: List[str], cpu_codename: CPUCodeName) -> List[MetricName]:
+    """Filter out events that cannot be collected on given cpu."""
+
+    filtered_event_names = []
+
+    for event_name in event_names:
+        if event_name in pc.HardwareEventNameMap:
+            # Universal metrics that works on all cpus.
+            filtered_event_names.append(event_name)
+        elif event_name in pc.PREDEFINED_RAW_EVENTS:
+            if cpu_codename in pc.PREDEFINED_RAW_EVENTS[event_name]:
+                filtered_event_names.append(event_name)
+            else:
+                log.warning('Event %r not supported for %s!', event_name, cpu_codename.value)
+                continue
+        elif '__r' in event_name:
+            # Pass all raw events.
+            filtered_event_names.append(event_name)
+        else:
+            raise Exception('Unknown event name %r!' % event_name)
+
+    return filtered_event_names

--- a/wca/perf.py
+++ b/wca/perf.py
@@ -219,6 +219,8 @@ def _create_file_from_fd(pfd):
         errno = ctypes.get_errno()
         if errno == INVALID_ARG_ERRNO:
             raise UnableToOpenPerfEvents('Invalid perf event file descriptor: {}, {}. '
+                                         'For cgroup based perf counters it may indicate there is '
+                                         'no enough hardware counters for measure all metrics!'
                                          'If traceback shows problem in perf_uncore '
                                          'it could be problem with PERF_FORMAT_GROUP in'
                                          'perf_event_attr structure for perf_event_open syscall.'

--- a/wca/runners/measurement.py
+++ b/wca/runners/measurement.py
@@ -34,7 +34,7 @@ from wca.metrics import Metric, MetricName, MissingMeasurementException, \
     MetricGranularity, MetricMetadata
 from wca.nodes import Node, Task
 from wca.nodes import TaskSynchronizationException
-from wca.perf import check_out_perf_event_names, filter_out_event_names_for_cpu
+from wca.perf import check_perf_event_count_limit, filter_out_event_names_for_cpu
 from wca.perf_uncore import UncorePerfCounters, _discover_pmu_uncore_config, \
     UNCORE_IMC_EVENTS, PMUNotAvailable, UncoreDerivedMetricsGenerator, \
     UNCORE_UPI_EVENTS
@@ -311,7 +311,7 @@ class MeasurementRunner(Runner):
         log.debug('Enabling perf events: %s', ', '.join(self._event_names))
         # Check and assume most popular number of available number of HW counters.
         if self._event_names:
-            if not check_out_perf_event_names(self._event_names, platform.cpus, platform.cores):
+            if not check_perf_event_count_limit(self._event_names, platform.cpus, platform.cores):
                 return 1
 
         # We currently do not support RDT without monitoring.


### PR DESCRIPTION
1. During E2E tests, echa build image will have name of branch as tag
2. Upon starting WCA, perform a check to make sure that there is enough PMU counters available  (assuming 8 for non-ht and 4 for ht enabled platforms, verified on BDX, SKX and CLX)