### PR TITLE
Update documentation - centos 7.6 as requirement and build pex in doc…

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -97,6 +97,11 @@ Steps to run WCA:
     #   work with docker option of installing dependencies.
     sudo env PYTHONPATH=. `pipenv --py` wca/main.py --config $PWD/configs/extra/static_allocator.yaml --root
 
+Used configuration files:
+
+- `measurements-only config <configs/extra/static_allocator.yaml>`_,
+- `static allocator with predifined rules <configs/extra/static_allocator.yaml>`_.
+
 Running these commands outputs metrics in Prometheus format to standard error like this:
 
 .. code-block:: ini

--- a/README.rst
+++ b/README.rst
@@ -101,6 +101,7 @@ Used configuration files:
 
 - `measurements-only config <configs/extra/static_measurements.yaml>`_,
 - `static allocator with predifined rules <configs/extra/static_allocator.yaml>`_.
+    - `predifined rules <configs/extra/static_allocator_config.yaml>`_.
 
 Running these commands outputs metrics in Prometheus format to standard error like this:
 

--- a/README.rst
+++ b/README.rst
@@ -42,15 +42,16 @@ See `WCA Architecture 1.7.pdf`_ for further details.
 Getting started
 ===============
 
-
-WCA is targeted at and tested on Centos 7.6.
+WCA is targeted at and tested on Centos 7.6
+(WCA should work on earlier versions of centos or other Linux distributions, however it is tested only on centos 7.6).
 
 *Note*: for full production installation please follow this detailed `installation guide <docs/install.rst>`_.
+
+To install WCA dependencies and build WCA pex file:
 
 .. code-block:: shell
 
     # Install required software.
-    sudo yum install epel-release -y
     sudo yum install git python3 make which python3-pip -y
     python3 -mpip install --user pipenv
     export PATH=$PATH:~/.local/bin
@@ -59,9 +60,12 @@ WCA is targeted at and tested on Centos 7.6.
     git clone https://github.com/intel/workload-collocation-agent
     cd workload-collocation-agent
     
-    export LC_ALL=en_US.utf8 #required for centos docker image
-    make venv
+    export LC_ALL=en_US.utf8  # required for centos docker image
     make wca_package
+
+To run resulting pex file:
+
+.. code-block:: shell
 
     # Prepare tasks manually (only cgroups are required)
     sudo mkdir -p /sys/fs/cgroup/{cpu,cpuset,cpuacct,memory,perf_event}/task1
@@ -72,9 +76,13 @@ WCA is targeted at and tested on Centos 7.6.
     # Example of static allocation with predefined rules on predefined list of tasks.
     sudo dist/wca.pex --config $PWD/configs/extra/static_allocator.yaml --root
 
-    # For development purposes can be also run from sources (requires venv create by pipenv)
-    sudo env PYTHONPATH=. `pipenv --py` wca/main.py --config $PWD/configs/extra/static_allocator.yaml --root
 
+To run WCA from sources: 
+
+.. code-block:: ini
+
+    make venv  # creates venv by pipenv
+    sudo env PYTHONPATH=. `pipenv --py` wca/main.py --config $PWD/configs/extra/static_allocator.yaml --root
 
 Running those commands outputs metrics in Prometheus format to standard error like this:
 

--- a/README.rst
+++ b/README.rst
@@ -12,10 +12,10 @@ WCA - Workload Collocation Agent
 Introduction
 ============
 
-Workload Collocation Agent's goal is to reduce interference between collocated tasks and increase tasks density while ensuring the quality of
-service for high priority tasks. Chosen approach allows to enable real-time resource isolation management
-to ensure that high priority jobs meet their Service Level Objective (SLO) and best-effort jobs
-effectively utilize as many idle resources as possible.
+Workload Collocation Agent's goal is to reduce interference between collocated tasks and increase tasks 
+density while ensuring the quality of service for high priority tasks. Chosen approach allows to 
+enable real-time resource isolation management to ensure that high priority jobs meet their 
+Service Level Objective (SLO) and best-effort jobs effectively utilize as many idle resources as possible.
 
 Resource usage can be increased by:
 

--- a/README.rst
+++ b/README.rst
@@ -212,7 +212,7 @@ See `external detector example <docs/external_detector_example.rst>`_ for more d
 Components
 ----------
 
-Following built-in components are available (stable API, refer to `API documentation <api.rst>`_ for full documentation):
+Following built-in components are available (stable API; refer to `API documentation <docs/api.rst>`_ for full documentation):
 
 - `MesosNode <docs/api.rst#mesosnode>`_ provides workload discovery on Mesos cluster node where `mesos containerizer <http://mesos.apache.org/documentation/latest/mesos-containerizer/>`_ is used (see the `Mesos docs here <docs/mesos.rst>`_)
 - `KubernetesNode <docs/api.rst#kubernetesnode>`_ provides workload discovery on Kubernetes cluster node (see the docs `here <docs/kubernetes.rst>`_)

--- a/README.rst
+++ b/README.rst
@@ -99,7 +99,7 @@ Steps to run WCA:
 
 Used configuration files:
 
-- `measurements-only config <configs/extra/static_allocator.yaml>`_,
+- `measurements-only config <configs/extra/static_measurements.yaml>`_,
 - `static allocator with predifined rules <configs/extra/static_allocator.yaml>`_.
 
 Running these commands outputs metrics in Prometheus format to standard error like this:

--- a/README.rst
+++ b/README.rst
@@ -47,10 +47,11 @@ WCA is targeted at and tested on Centos 7.6
 
 *Note*: for full production installation please follow this detailed `installation guide <docs/install.rst>`_.
 
-To install WCA dependencies and build WCA pex file:
+Steps needed to install WCA dependencies and build WCA pex file:
 
+.. _installing_dependencies_manually:
 .. code-block:: shell
-
+    
     # Install required software.
     sudo yum install git python3 make which python3-pip -y
     python3 -mpip install --user pipenv
@@ -61,9 +62,23 @@ To install WCA dependencies and build WCA pex file:
     cd workload-collocation-agent
     
     export LC_ALL=en_US.utf8  # required for centos docker image
+    make venv  # creates venv by pipenv
     make wca_package
 
-To run resulting pex file:
+or using docker:
+
+.. code-block:: shell
+
+    # needed only on host, where pex file is run
+    sudo yum install python3
+
+    # needed on host, where pex file is builded
+    sudo yum install make
+
+    # pex file will be copied to ./dist/wca.pex
+    make wca_package_in_docker
+
+Steps to run WCA:
 
 .. code-block:: shell
 
@@ -76,13 +91,6 @@ To run resulting pex file:
     # Example of static allocation with predefined rules on predefined list of tasks.
     sudo dist/wca.pex --config $PWD/configs/extra/static_allocator.yaml --root
 
-
-To run WCA from sources: 
-
-.. code-block:: ini
-
-    make venv  # creates venv by pipenv
-    sudo env PYTHONPATH=. `pipenv --py` wca/main.py --config $PWD/configs/extra/static_allocator.yaml --root
 
 Running those commands outputs metrics in Prometheus format to standard error like this:
 
@@ -134,6 +142,12 @@ Running those commands outputs metrics in Prometheus format to standard error li
     # TYPE wca_tasks gauge
     wca_tasks{host="gklab-126-081"} 1 1575625088768
 
+
+To run WCA agent from source code, please _installing_dependencies_manually.
+
+.. code-block:: ini
+
+    sudo env PYTHONPATH=. `pipenv --py` wca/main.py --config $PWD/configs/extra/static_allocator.yaml --root
 
 When reconfigured, other built-in components allow to:
 

--- a/README.rst
+++ b/README.rst
@@ -100,8 +100,7 @@ Steps to run WCA:
 Used configuration files:
 
 - `measurements-only config <configs/extra/static_measurements.yaml>`_,
-- `static allocator with predifined rules <configs/extra/static_allocator.yaml>`_.
-    - `predifined rules <configs/extra/static_allocator_config.yaml>`_.
+- `static allocator with predifined rules <configs/extra/static_allocator.yaml>`_ (`predifined rules <configs/extra/static_allocator_config.yaml>`_).
 
 Running these commands outputs metrics in Prometheus format to standard error like this:
 

--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,6 @@ WCA is targeted at and tested on Centos 7.6
 
 Steps needed to install WCA dependencies and build WCA pex file:
 
-.. _installing_dependencies_manually:
 .. code-block:: shell
     
     # Install required software.
@@ -82,8 +81,11 @@ Steps to run WCA:
 
 .. code-block:: shell
 
-    # Prepare tasks manually (only cgroups are required)
+    # Configuration files used in below commands requires creating a cgroup with name `task1`.
     sudo mkdir -p /sys/fs/cgroup/{cpu,cpuset,cpuacct,memory,perf_event}/task1
+
+    # Add a process to the cgroup to monitor it using WCA. Might be skipped.
+    echo $PROCESS_PID > /sys/fs/cgroup/{cpu,cpuset,cpuacct,memory,perf_event}/task1/tasks
 
     # Example of running agent in measurements-only mode with predefined static list of tasks
     sudo dist/wca.pex --config $PWD/configs/extra/static_measurements.yaml --root
@@ -91,8 +93,11 @@ Steps to run WCA:
     # Example of static allocation with predefined rules on predefined list of tasks.
     sudo dist/wca.pex --config $PWD/configs/extra/static_allocator.yaml --root
 
+    # The same as 2nd command, but run from source code - does **not** 
+    #   work with docker option of installing dependencies.
+    sudo env PYTHONPATH=. `pipenv --py` wca/main.py --config $PWD/configs/extra/static_allocator.yaml --root
 
-Running those commands outputs metrics in Prometheus format to standard error like this:
+Running these commands outputs metrics in Prometheus format to standard error like this:
 
 .. code-block:: ini
 
@@ -143,11 +148,6 @@ Running those commands outputs metrics in Prometheus format to standard error li
     wca_tasks{host="gklab-126-081"} 1 1575625088768
 
 
-To run WCA agent from source code, please _installing_dependencies_manually.
-
-.. code-block:: ini
-
-    sudo env PYTHONPATH=. `pipenv --py` wca/main.py --config $PWD/configs/extra/static_allocator.yaml --root
 
 When reconfigured, other built-in components allow to:
 

--- a/README.rst
+++ b/README.rst
@@ -212,7 +212,7 @@ See `external detector example <docs/external_detector_example.rst>`_ for more d
 Components
 ----------
 
-Following built-in components are available (stable API):
+Following built-in components are available (stable API, refer to `API documentation <api.rst>`_ for full documentation):
 
 - `MesosNode <docs/api.rst#mesosnode>`_ provides workload discovery on Mesos cluster node where `mesos containerizer <http://mesos.apache.org/documentation/latest/mesos-containerizer/>`_ is used (see the `Mesos docs here <docs/mesos.rst>`_)
 - `KubernetesNode <docs/api.rst#kubernetesnode>`_ provides workload discovery on Kubernetes cluster node (see the docs `here <docs/kubernetes.rst>`_)

--- a/README.rst
+++ b/README.rst
@@ -85,7 +85,7 @@ Steps to run WCA:
     sudo mkdir -p /sys/fs/cgroup/{cpu,cpuset,cpuacct,memory,perf_event}/task1
 
     # Add a process to the cgroup to monitor it using WCA. Might be skipped.
-    echo $PROCESS_PID > /sys/fs/cgroup/{cpu,cpuset,cpuacct,memory,perf_event}/task1/tasks
+    sudo bash -c 'echo $PROCESS_PID > /sys/fs/cgroup/{cpu,cpuset,cpuacct,memory,perf_event}/task1/tasks'
 
     # Example of running agent in measurements-only mode with predefined static list of tasks
     sudo dist/wca.pex --config $PWD/configs/extra/static_measurements.yaml --root

--- a/configs/extra/static_allocator.yaml
+++ b/configs/extra/static_allocator.yaml
@@ -3,8 +3,6 @@ runner: !AllocationRunner
     node: !StaticNode
       tasks:
         - task1
-        # - task2
-        # - task3
 
   allocator: !StaticAllocator
     config: configs/extra/static_allocator_config.yaml

--- a/docs/allocation.rst
+++ b/docs/allocation.rst
@@ -37,7 +37,7 @@ For more information about ``MeasurementRunner`` please refer to `Measurement AP
 All information about existing allocations, detected anomalies or other metrics are stored in
 corresponding storage classes.
 
-Please refer to `API documentation of AllocationRunner <docs/api.rst#AllocationRunner>`_ for full
+Please refer to `API documentation of AllocationRunner <api.rst#AllocationRunner>`_ for full
 list of available parameters of ``AllocationRunner``.
 
 .. code-block:: python

--- a/docs/allocation.rst
+++ b/docs/allocation.rst
@@ -37,48 +37,8 @@ For more information about ``MeasurementRunner`` please refer to `Measurement AP
 All information about existing allocations, detected anomalies or other metrics are stored in
 corresponding storage classes.
 
-
-``AllocationRunner`` class has the following required and optional attributes:
-
-.. code-block:: python
-
-        class AllocationRunner(Runner):
-            """Runner is responsible for getting information about tasks from node,
-            calling allocate() callback on allocator, performing returning allocations
-            and storing all allocation related metrics in allocations_storage.
-
-            Because Allocator interface is also detector, we store serialized detected anomalies
-            in anomalies_storage and all other measurements in metrics_storage.
-
-            Arguments:
-                measurement_runner: Measurement runner object.
-                allocator: Component that provides allocation logic.
-                anomalies_storage: Storage to store serialized anomalies and extra metrics.
-                    (defaults to DEFAULT_STORAGE/LogStorage to output for standard error)
-                allocations_storage: Storage to store serialized resource allocations.
-                    (defaults to DEFAULT_STORAGE/LogStorage to output for standard error)
-                rdt_mb_control_required: Indicates that MB control is required,
-                    if the platform does not support this feature the WCA will exit.
-                rdt_cache_control_required: Indicates tha L3 control is required,
-                    if the platform does not support this feature the WCA will exit.
-                remove_all_resctrl_groups (bool): Remove all RDT controls groups upon starting.
-                    (defaults to False)
-            """
-
-            def __init__(
-                    self,
-                    measurement_runner: MeasurementRunner,
-                    allocator: Allocator,
-                    allocations_storage: Storage = DEFAULT_STORAGE,
-                    anomalies_storage: Storage = DEFAULT_STORAGE,
-                    rdt_mb_control_required: bool = False,
-                    rdt_cache_control_required: bool = False,
-                    remove_all_resctrl_groups: bool = False
-            ):
-        ...
-
-
-``AllocationConfiguration`` contains static configuration to perform normalization of specific resource allocations.
+Please refer to `API documentation of AllocationRunner <docs/api.rst#AllocationRunner>`_ for full
+list of available parameters of ``AllocationRunner``.
 
 .. code-block:: python
 

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -13,11 +13,9 @@ Preparing developer environment
 
 1. Install `epel-release` repository and basic developer tools:
 
-:Note: For Centos 7.6 Python 3.6 is already available, so you **do not** need to install epel-release.
-
 .. code-block:: shell
 
-    yum install epel-release make git which
+    yum install make git which
 
 Note: that on production system, you should use Python 3.6 as describe `here <install.rst>`_.
 
@@ -25,7 +23,7 @@ Note: that on production system, you should use Python 3.6 as describe `here <in
 
 .. code-block:: shell
 
-    yum install python36
+    yum install python3
 
 Getting source code and preparing python virtualenv
 ---------------------------------------------------
@@ -104,7 +102,7 @@ You can run without building a distribution like this:
 
 .. code-block:: shell
     
-    python3.6 -mpipenv shell
+    python3 -mpipenv shell
     sudo env PYTHONPATH=. `which python` wca/main.py --root -c configs/extra/static_measurements.yaml
 
 
@@ -113,7 +111,7 @@ Using example allocator:
 
 .. code-block:: shell
 
-    python3.6 -mpipenv shell
+    python3 -mpipenv shell
     sudo env PYTHONPATH=. `which python` wca/main.py --root -c configs/extra/static_allocator.yaml
 
 Fast distribution rebuild

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -30,13 +30,7 @@ Getting source code and preparing python virtualenv
 
 WCA uses `pipenv <https://pipenv.readthedocs.io/en/latest/>`_ to create python virtualenv with all tools required to run, validate and build the project.
 
-1. Install pip using 3.6 Python interpreter (available in ``epel`` release and "Software Collections" python collections:
-
-.. code-block:: shell
-
-    python -m ensurepip
-
-2. Install pipenv in user mode:
+1. Install pipenv in user mode:
 
 .. code-block:: shell
 
@@ -48,25 +42,25 @@ See `pragmatic installation of pipenv`_ for more details on installing pipenv.
 
 .. _`pragmatic installation of pipenv`: https://docs.pipenv.org/install/#pragmatic-installation-of-pipenv
 
-3. Clone WCA repository:
+2. Clone WCA repository:
 
 .. code-block:: shell
 
     git clone https://github.com/intel/workload-collocation-agent
 
-4. Further commands should be run from wca root directory:
+3. Further commands should be run from wca root directory:
 
 .. code-block:: shell
 
     cd workload-collocation-agent
 
-5. Prepare virtual environment for WCA:
+4. Prepare virtual environment for WCA:
 
 .. code-block:: shell
 
     pipenv install --dev
 
-6. Start using newly created virtualenv:
+5. Start using newly created virtualenv:
 
 .. code-block:: shell
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -12,27 +12,25 @@ Building PEX distribution
 Building requirements
 ---------------------
 
-Please follow the instructions from `development guide <development.rst>`_ to prepare
-following items:
+To build WCA pex distribution file one need:
 
-- python 3.6
-- git
-- pip
-- pipenv 
-- make
-- which (required by pipenv)
-- source code of wca
+- GNU make
+- docker
 
 Building executable binary (distribution)
 -----------------------------------------
 
+To build pex file inside docker (`Dockerfile <Dockerfile>`_ is used), please run:
+
 .. code:: shell
 
-   make wca_package
+   make wca_package_in_docker
+
+The command will result in creation of ``dist/wca.pex`` file.
 
 File ``dist/wca.pex`` must be copied to ``/usr/bin/wca.pex``.
 
-To build distribution file with support for storing metrics in Kafka please follow
+To build distribution file with support for storing metrics in `Apache Kafka <https://kafka.apache.org>`_ please follow
 `Building executable binary with KafkaStorage component enabled <kafka_storage.rst>`_ guide.
 
 Running
@@ -41,11 +39,15 @@ Running
 Runtime requirements
 --------------------
 
-- Hardware with `Intel RDT <https://www.intel.com/content/www/us/en/architecture-and-technology/resource-director-technology.html>`_ support.
-- Centos 7.5 with at least 3.10.0-862 kernel with support of `resctrl filesystem <https://www.kernel.org/doc/Documentation/x86/intel_rdt_ui.txt>`_.
-- Python 3.6.x 
+- Centos 7.6 with at least 3.10.0-862 kernel with support of `resctrl filesystem <https://www.kernel.org/doc/Documentation/x86/intel_rdt_ui.txt>`_ 
+  (WCA should work on earlier versions of centos or other Linux distributions, however it is tested only on centos 7.6)
+- Python 3.6.x
 
-All other the software dependencies are bundled using `PEX <https://github.com/pantsbuild/pex>`_.
+All other WCA dependencies are bundled using `PEX <https://github.com/pantsbuild/pex>`_.
+
+For RDT related features:
+
+- Hardware with `Intel RDT <https://www.intel.com/content/www/us/en/architecture-and-technology/resource-director-technology.html>`_ support.
 
 RDT enabling on Skylake processor
 ---------------------------------
@@ -66,32 +68,17 @@ To enable RDT please add kernel boot time parameters ``rdt=cmt,mbmtotal,mbmlocal
 Python 3.6 Centos installation (recommended)
 --------------------------------------------
 
-:Note: For Centos 7.6 Python 3.6 is already available, so you **do not** need to install epel-release.
+.. code:: shell
 
-The recommended way of installing Python 3.6.x is to use `Software Collections <https://www.softwarecollections.org/en/>`_.
-SCL repository is maintained by a CentOS SIG.
-
-Please use `official installation guide <https://www.softwarecollections.org/en/scls/rhscl/rh-python36/>`_ to install Python 3.6 on target hosts.
+    yum install python3  # centos 7.6
 
 Then, verify that Python is installed correctly::
 
-    /usr/bin/scl enable rh-python36 'python --version'
+    python3 --version
 
 Should output::
     
-    Python 3.6.3
-
-Alternative options for Python 3.6 installation 
------------------------------------------------
-
-To simplify python interpreter management (no need to use ``scl`` tool as prefix), 
-you can use Intel Distribution for Python according to `yum-based installation guide <https://software.intel.com/en-us/articles/installing-intel-free-libs-and-python-yum-repo>`_.
-or use community maintained third-party ``epel`` repository and install ``python36`` package from there::
-
-    yum install epel-release
-    yum install python36
-
-CentOS project does not support, nor provide ``epel`` repository.
+    Python 3.6.x
 
 
 Running WCA as non-root user
@@ -149,11 +136,13 @@ Please use following `template <../configs/systemd-unit/wca.service>`_ as system
 
 where:
 
-``$EXTRA_COMPONENT`` should be replaced with name of a class e.g. ``wca.allocators:NOPAllocator``.
+``--register`` flag is needed if external plugin needs to be used. 
+``$EXTRA_COMPONENT`` should be replaced with name of a class e.g. ``your_custom_module.allocators:YourCustomAllocator``.
 Class name must comply with `pkg_resources <https://setuptools.readthedocs.io/en/latest/pkg_resources.html#id2>`_ format.
 All dependencies of the class must be available in currently used `PYTHONPATH`.
 
-You can use ``wca.allocators:NOPAllocator`` that is already bundled within ``dist/wca.pex`` file and does not have to be registered(if you decide to use it remove registration from `wca.service` file).
+You can use ``wca.allocators:NOPAllocator`` that is already bundled within ``dist/wca.pex`` file and does not have to be registered
+(if you decide to use it remove registration from `wca.service` file).
 
 :note: Running wca with dedicated "wca" user is more secure, but requires enabling perf counters to be used by non-root users.
        You need to reconfigure ``perf_event_paranoid`` sysctl paramter like this:
@@ -174,22 +163,15 @@ Config ``/etc/wca/wca_config.yml`` must exists. See an `example configuration fi
         timeout: 5
         interval: 1.
         metrics_storage: !LogStorage
-          output_filename: '/tmp/output_anomalies.log'    
+          output_filename: '/tmp/metrics_storage.log'    
         extra_labels:
           env_id: "$HOST_IP"
-        anomalies_storage: !KafkaStorage
-            brokers_ips: ['$KAFKA_BROKER_IP:9092']
-            topic: wca_anomalies
-            max_timeout_in_seconds: 5.
+        anomalies_storage: !LogStorage
+          output_filename: '/tmp/anomalies_storage.log'    
         allocator: !NOPAllocator
             ...
         ...
             
-
-Apply following changes to the file above:
-
-- ``$KAFKA_BROKER`` must be replaced with IP address of Kafka broker,
-- ``$HOST_IP`` may be replaced with host IP address to tag all metrics originating from WCA process
 
 Following configuration is required in order to use ``MesosNode`` component to discover new tasks:
 
@@ -202,4 +184,3 @@ Following configuration is required in order to use ``MesosNode`` component to d
    - ``cgroups/perf_event``.
 - Mesos agent must expose operator API over `secure socket <http://mesos.apache.org/documentation/latest/ssl/>`_. WCA TLS can be disabled in configuration by modifying ``mesos_agent_endpoint`` property.
 - Mesos agent may be `configured <http://mesos.apache.org/documentation/latest/configuration/agent/#image_providers>`_ to use Docker registry to fetch images. 
-

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -20,7 +20,7 @@ To build WCA pex distribution file one need:
 Building executable binary (distribution)
 -----------------------------------------
 
-To build pex file inside docker (`Dockerfile <Dockerfile>`_ is used), please run:
+To build pex file inside docker (`Dockerfile <../Dockerfile>`_ is used), please run:
 
 .. code:: shell
 

--- a/docs/kafka_storage.rst
+++ b/docs/kafka_storage.rst
@@ -13,7 +13,7 @@ To support this feature WCA uses libraries:
 Building executable binary (distribution)
 -----------------------------------------
 
-To build executable binary inside a docker using `Dockerfile <Dockerfile.kafka>`_, run:
+To build executable binary inside a docker (using `Dockerfile <../Dockerfile.kafka>`_), run:
 
 .. code:: shell
 

--- a/docs/kafka_storage.rst
+++ b/docs/kafka_storage.rst
@@ -1,51 +1,30 @@
 Building executable binary with KafkaStorage component enabled
 --------------------------------------------------------------
 
-If there is need to store metrics from WCA, **KafkaStorage** component
-can be used. The component requires `confluent-kafka-python package <https://github.com/confluentinc/confluent-kafka-python>`_,
-which by default is not included in the pex WCA distribution file.
+If there is need to store metrics from WCA in `Apache Kafka <https://kafka.apache.org>`_,
+**KafkaStorage** component can be used. 
 
-To build pex file with confluent-kafka-python package one should:
+To support this feature WCA uses libraries: 
 
-* follow part "Get the software" points 1-4 from `confluent guide <https://docs.confluent.io/current/installation/installing_cp/rhel-centos.html>`_ 
-* install librdkafka1 and librdkafka-devel-1.0.0_confluent5.2.2-1.el7.x86_64 packages
-* install gcc, python3 development files (for centos 7: gcc, python36-devel.x86_64)
-* clone repository confluent-kafka-python in root repository directory to the directory confluent-kafka-python,
-* checkout the repository to tag **v1.0.1**
-* while building Makefile target **wca_package** set variable **OPTIONAL_FEATURES** to `kafka_storage`.
+- `librdkafka <https://github.com/edenhill/librdkafka>`_
+- `confluent-kafka-python package <https://github.com/confluentinc/confluent-kafka-python>`_
 
-All commands which needs to be run to build WCA pex file with **KafkaStorage** component enabled are as follow for centos7:
+
+Building executable binary (distribution)
+-----------------------------------------
+
+To build executable binary inside a docker using `Dockerfile <Dockerfile.kafka>`_, run:
 
 .. code:: shell
 
-    sudo rpm --import https://packages.confluent.io/rpm/5.2/archive.key
-    sudo tee /etc/yum.repos.d/confluent.repo > /dev/null <<'EOF'
-    [Confluent.dist]
-    name=Confluent repository (dist)
-    baseurl=https://packages.confluent.io/rpm/5.2/7
-    gpgcheck=1
-    gpgkey=https://packages.confluent.io/rpm/5.2/archive.key
-    enabled=1
+   make wca_package_in_docker_with_kafka
 
-    [Confluent]
-    name=Confluent repository
-    baseurl=https://packages.confluent.io/rpm/5.2
-    gpgcheck=1
-    gpgkey=https://packages.confluent.io/rpm/5.2/archive.key
-    enabled=1
-    EOF
+Runtime requirements
+--------------------
 
-    sudo yum clean all && sudo yum install -y librdkafka1 librdkafka-devel-1.0.0_confluent5.2.2-1.el7.x86_64
-    sudo yum install -y gcc python36-devel.x86_64
-
-    git clone https://github.com/confluentinc/confluent-kafka-python
-    cd confluent-kafka-python
-    git checkout v1.0.1
-    cd ..
-    make wca_package OPTIONAL_FEATURES=kafka_storage
-
-One needs librdkafka 1.0.x on machine where pex file will be run.
-To install only librdkafka library:
+One needs `librdkafka <https://github.com/edenhill/librdkafka>`_ of version **1.0.x**
+on machine where pex file will be run.  Run commands to install it on centos 7
+(taken from `confluent guide <https://docs.confluent.io/current/installation/installing_cp/rhel-centos.html>`_):
 
 .. code:: shell
 
@@ -67,16 +46,3 @@ To install only librdkafka library:
     EOF
 
     sudo yum clean all && sudo yum install -y librdkafka1
-
-
-Unsafe method
--------------
-We strongly advise to build the confluent-kafka-python manually due to security reasons. 
-Wheel manylinux package included in PyPi contains bundled binary libraries, where some of them 
-are outdated (e.g. zlib1.2.3 is included in the package and contains security vulnerabilities).
-Hovewer, if You want to use the package from PyPi and skip all steps described here please run:
-
-.. code:: shell
-
-    export INCLUDE_UNSAFE_CONFLUENT_KAFKA_WHEEL=yes
-    make wca_package

--- a/docs/measurement.rst
+++ b/docs/measurement.rst
@@ -28,38 +28,4 @@ Example of configuration that uses ``MeasurementRunner``:
 Available arguments
 -------------------
 
-node: 
-        Component used for tasks discovery.
-metrics_storage:
-        Storage to store platform, internal, resource and task metrics.
-        (defaults to DEFAULT_STORAGE/LogStorage to output for standard error)
-interval:
-        Iteration duration in seconds (None disables wait and iterations).
-        (defaults to 1 second)
-rdt_enabled:
-        Enables or disabled support for RDT monitoring.
-        (defaults to None(auto) based on platform capabilities)
-gather_hw_mm_topology:
-        Gather hardware/memory topology based on lshw and ipmctl.
-        (defaults to False)
-extra_labels:
-        Additional labels attached to every metrics.
-        (defaults to empty dict)
-event_names:
-        Perf counters to monitor.
-        (defaults to instructions, cycles, cache-misses, memstalls)
-enable_derived_metrics:
-        Enable derived metrics ips, ipc and cache_hit_ratio.
-        (based on enabled_event names, default to False)
-enable_perf_uncore:
-        Enable perf event uncore metrics.
-        (defaults to True)
-task_label_generators:
-        Component to generate additional labels for tasks.
-        (optional)
-allocation_configuration: 
-        Allows fine grained control over allocations.
-        (defaults to AllocationConfiguration() instance)
-wss_reset_interval:
-        Interval of reseting wss.
-        (defaults to 0, no reseting)
+Please refer to `API documentation of MeasurementRunner <docs/api.rst#MeasurementRunner>`_.

--- a/docs/measurement.rst
+++ b/docs/measurement.rst
@@ -25,6 +25,7 @@ Example of configuration that uses ``MeasurementRunner``:
             output_filename: 'metrics.prom'
             overwrite: true
 
+
 Available arguments
 -------------------
 

--- a/docs/measurement.rst
+++ b/docs/measurement.rst
@@ -28,4 +28,4 @@ Example of configuration that uses ``MeasurementRunner``:
 Available arguments
 -------------------
 
-Please refer to `API documentation of MeasurementRunner <docs/api.rst#MeasurementRunner>`_.
+Please refer to `API documentation of MeasurementRunner <api.rst#MeasurementRunner>`_.


### PR DESCRIPTION
Update documentation - centos 7.6 as requirement and build pex in docker.

- replace make wca_package with wca_package_in_docker in install guide
- make python3.6 from centos 7.6 official way of installing dep for WCA (we required centos 7.6)
- https://github.com/intel/workload-collocation-agent/blob/master/docs/measurement.rst instead of copying API from code, put link do docs/api.rst to appropriate paragraph listing MeasurementRunner arguments