### PR TITLE
Workaround for broken cpuacct.usage counter from multi container Pods

### DIFF
--- a/tests/runners/test_runners_allocation.py
+++ b/tests/runners/test_runners_allocation.py
@@ -31,12 +31,14 @@ _os_tasks_allocations = {
 
 
 @prepare_runner_patches
+@patch('wca.cgroups.Cgroup.reset_counters')
 @patch('wca.containers.Container.get_allocations',    return_value=_os_tasks_allocations)
 @patch('wca.containers.ContainerSet.get_allocations', return_value=_os_tasks_allocations)
 @patch('wca.platforms.collect_platform_information', return_value=(platform_mock, [], {}))
 @pytest.mark.parametrize('subcgroups', ([], ['/T/c1'], ['/T/c1', '/T/c2']))
 def test_allocation_runner(
-        _get_allocations_mock, _get_allocations_mock_, platform_mock, subcgroups):
+        _get_allocations_mock, _get_allocations_mock_, platform_mock,
+        reset_counter_mock, subcgroups):
     """ Low level system calls are not mocked - but higher level objects and functions:
         Cgroup, Resgroup, Platform, etc. Thus the test do not cover the full usage scenario
         (such tests would be much harder to write).

--- a/tests/runners/test_runners_detection.py
+++ b/tests/runners/test_runners_detection.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -29,8 +29,9 @@ from wca.runners.measurement import MeasurementRunner
 
 
 @prepare_runner_patches
+@patch('wca.cgroups.Cgroup.reset_counters')
 @pytest.mark.parametrize('subcgroups', ([], ['/T/c1'], ['/T/c1', '/T/c2']))
-def test_detection_runner(subcgroups):
+def test_detection_runner(reset_counters_mock, subcgroups):
     # Tasks mock
     t1 = redis_task_with_default_labels('t1', subcgroups)
     t2 = redis_task_with_default_labels('t2', subcgroups)

--- a/tests/runners/test_runners_measurement.py
+++ b/tests/runners/test_runners_measurement.py
@@ -63,8 +63,9 @@ def test_measurements_runner_init_and_checks(rdt_enabled, resctrl_available,
 
 
 @prepare_runner_patches
+@patch('wca.cgroups.Cgroup.reset_counters')
 @pytest.mark.parametrize('subcgroups', ([], ['/T/c1'], ['/T/c1', '/T/c2']))
-def test_measurements_runner(subcgroups):
+def test_measurements_runner(reset_counters_mock, subcgroups):
     # Node mock
     t1 = redis_task_with_default_labels('t1', subcgroups)
     t2 = redis_task_with_default_labels('t2', subcgroups)

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -92,6 +92,7 @@ def test_find_new_and_dead_tasks(discovered_tasks, containers,
 @patch('wca.perf.PerfCounters')
 @patch('wca.containers.Container.sync')
 @patch('wca.containers.Container.get_pids')
+@patch('wca.cgroups.Cgroup.reset_counters')
 @pytest.mark.parametrize('subcgroups', ([], ['/t1/c1', '/t1/c2']))
 @pytest.mark.parametrize(
     'tasks_, pre_running_containers_, mon_groups_relation,'
@@ -117,7 +118,7 @@ def test_find_new_and_dead_tasks(discovered_tasks, containers,
              {}, {}, {}),
     )
 )
-def test_sync_containers_state(_, get_pids_mock, sync_mock, perf_counters_mock,
+def test_sync_containers_state(_, reset_counter_mock, get_pids_mock, sync_mock, perf_counters_mock,
                                add_pids_mock, clean_taskless_groups_mock,
                                subcgroups,
                                tasks_, pre_running_containers_,

--- a/tests/testing.py
+++ b/tests/testing.py
@@ -336,6 +336,7 @@ def prepare_runner_patches(func):
              patch('resource.getrusage', return_value=Mock(ru_maxrss=WCA_MEMORY_USAGE)), \
              patch('wca.perf_uncore.UncorePerfCounters._open'), \
              patch('wca.perf.PerfCounters._open'):
+
             func(*args, **kwargs)
 
     return _decorated_function

--- a/wca/cgroups.py
+++ b/wca/cgroups.py
@@ -96,6 +96,32 @@ class Cgroup:
         self.cgroup_memory_fullpath = os.path.join(CgroupSubsystem.MEMORY,
                                                    relative_cgroup_path)
 
+    def reset_counters(self):
+        """Reset counters managed by cgroup abstraction.
+
+        After one of the container from Pod restarts, the cgroup is reused, but
+        cpuacct.usage still holds a value from previus unsucessful runs.
+        For multicontainer Pods there is a problem when long lived sum of counters
+        from all containers is slightly decreased, because any decrease in counter
+        is treated by Prometheus as reset and then it is assumed that "total value" is
+        last period decrese causing unrealistics spikes in counter rate/increase.
+        There are two solitions:
+        1. Make sure that after we reintialize cgroups, we will reset all the counters
+           (This solution)
+        2. Do not aggregate counters (by summing), but expose them as as additional time
+           series (new metrics per container)
+           (To be considered, but requires API change (new levels) for some metrics)
+        ps. Cgroups solutions works because all other metrics:
+        are gauages (NUMA),  collected per POD (RDT) or properly reset to 0 (perf counters)
+        """
+        try:
+            with open(os.path.join(self.cgroup_cpu_fullpath, CgroupResource.CPU_USAGE), 'w') as \
+                    cpu_usage_file:
+                cpu_usage_file.write(0)
+        except FileNotFoundError as e:
+            raise MissingMeasurementException(
+                'File {} is missing. Cpu usage (to perfom reset) unavailable.'.format(e.filename))
+
     def get_measurements(self) -> Measurements:
         try:
             with open(os.path.join(self.cgroup_cpu_fullpath, CgroupResource.CPU_USAGE)) as \
@@ -155,10 +181,17 @@ class Cgroup:
             has_hierarchical_metrics = False
             get_metric("hierarchical_total=")
             if not has_hierarchical_metrics:
-                import warnings
-                warnings.warn(
-                    "No hierarchical_total in NUMA memory stat for tasks in cgroup. Using total=."
-                )
+                # NOTE: because we have no nested containers support
+                # total is ok and we do not need hierarhical total
+                # because we're alread collecting per container and aggregate
+                # for Pod
+                log.log(logger.TRACE, "No hierarchical_total in NUMA "
+                        "memory stat for tasks in cgroup. Using total=.")
+
+                # import warnings
+                # warnings.warn(
+                #     "No hierarchical_total in NUMA memory stat for tasks in cgroup. Using total=."
+                # )
                 get_metric("total=")
 
         except FileNotFoundError as e:

--- a/wca/cgroups.py
+++ b/wca/cgroups.py
@@ -117,7 +117,7 @@ class Cgroup:
         try:
             with open(os.path.join(self.cgroup_cpu_fullpath, CgroupResource.CPU_USAGE), 'w') as \
                     cpu_usage_file:
-                cpu_usage_file.write(0)
+                cpu_usage_file.write('0')
         except FileNotFoundError as e:
             raise MissingMeasurementException(
                 'File {} is missing. Cpu usage (to perfom reset) unavailable.'.format(e.filename))

--- a/wca/containers.py
+++ b/wca/containers.py
@@ -101,6 +101,10 @@ class ContainerInterface(ABC):
     def get_allocations(self) -> TaskAllocations:
         ...
 
+    @abstractmethod
+    def reset_counters(self):
+        ...
+
 
 class ContainerSet(ContainerInterface):
     def __init__(self,
@@ -139,6 +143,10 @@ class ContainerSet(ContainerInterface):
                 wss_reset_interval=wss_reset_interval,
                 perf_aggregate_cpus=perf_aggregate_cpus
             )
+
+    def reset_counters(self):
+        for container in self._subcontainers.values():
+            container.reset_counters()
 
     def get_subcgroups(self) -> List[cgroups.Cgroup]:
         return [container.get_cgroup() for container in
@@ -290,6 +298,12 @@ class Container(ContainerInterface):
             self._derived_metrics_generator = \
                 PerfCgroupDerivedMetricsGenerator(self._get_measurements)
 
+    def reset_counters(self):
+        # There is no other counters than cgroups.
+        # RDT is per Pod and doesn't need to be reset
+        # Perf counters are reset every time there are initialized.
+        self._cgroup.reset_counters()
+
     def __repr__(self):
         return 'Container(%r)' % self._cgroup_path
 
@@ -423,6 +437,8 @@ class ContainerManager:
                 wss_reset_interval=self._wss_reset_interval,
                 perf_aggregate_cpus=self._perf_aggregate_cpus
             )
+        # Every initialization aor reinitializaiotn should reset managed counters.
+        container.reset_counters()
         return container
 
     @profiler.profile_duration('sync_containers_state')


### PR DESCRIPTION
The root cause is that WCA sum counters, before rate and generally the only valid operation is rate first.

https://www.robustperception.io/rate-then-sum-never-sum-then-rate

This workaround should solve the issue of spike in rates for cpuacct.usage, but generally the proper solution would be exposing metrics per container.