### PR TITLE
Counter "cpuacct.usage" conversion fix.

### DIFF
--- a/wca/cgroups.py
+++ b/wca/cgroups.py
@@ -127,7 +127,7 @@ class Cgroup:
             with open(os.path.join(self.cgroup_cpu_fullpath, CgroupResource.CPU_USAGE)) as \
                     cpu_usage_file:
                 # scale to seconds
-                cpu_usage = float(cpu_usage_file.read()) / 1e9
+                cpu_usage = int(cpu_usage_file.read()) / 1e9
         except FileNotFoundError as e:
             raise MissingMeasurementException(
                 'File {} is missing. Cpu usage unavailable.'.format(e.filename))


### PR DESCRIPTION
Cgroups `cpuacct.usage` is a counter, so it should be threatened as decimal number.