### PR TITLE
Some debian package manager tweaks

### DIFF
--- a/examples/workloads/cassandra_stress/Dockerfile
+++ b/examples/workloads/cassandra_stress/Dockerfile
@@ -16,10 +16,10 @@
 FROM cassandra
 RUN ln -sfn /usr/bin/python2 /usr/bin/python
 RUN apt-get update && apt-get -y upgrade
-RUN apt -y install build-essential
-RUN apt -y install libssl-dev zlib1g-dev libncurses5-dev libncursesw5-dev libreadline-dev libsqlite3-dev
-RUN apt -y install libgdbm-dev libdb5.3-dev libbz2-dev libexpat1-dev liblzma-dev tk-dev
-RUN apt -y install wget
+RUN apt-get --no-install-recommends -y install build-essential
+RUN apt-get --no-install-recommends -y install libssl-dev zlib1g-dev libncurses5-dev libncursesw5-dev libreadline-dev libsqlite3-dev
+RUN apt-get --no-install-recommends -y install libgdbm-dev libdb5.3-dev libbz2-dev libexpat1-dev liblzma-dev tk-dev
+RUN apt-get --no-install-recommends -y install wget
 RUN wget https://www.python.org/ftp/python/3.6.6/Python-3.6.6.tar.xz
 RUN tar xf Python-3.6.6.tar.xz
 WORKDIR /Python-3.6.6
@@ -30,4 +30,4 @@ WORKDIR /
 COPY /dist/cassandra_stress_wrapper.pex /usr/bin/cassandra_stress_wrapper.pex
 RUN mkdir -p /stress
 
-RUN apt-get install -y netcat
+RUN apt-get --no-install-recommends -y install netcat


### PR DESCRIPTION
By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages .

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>