### PR TITLE
Rules for new 2LM score metric 

### DIFF
--- a/examples/kubernetes/monitoring/prometheus/2lm_score_dashboard.json
+++ b/examples/kubernetes/monitoring/prometheus/2lm_score_dashboard.json
@@ -1,0 +1,705 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 91,
+  "links": [],
+  "panels": [
+    {
+      "activePatternIndex": 1,
+      "datasource": "Prometheus-operator",
+      "defaultPattern": {
+        "bgColors": "green|orange|red",
+        "bgColors_overrides": "0->green|2->red|1->yellow",
+        "clickable_cells_link": "",
+        "col_name": "Value",
+        "decimals": 2,
+        "defaultBGColor": "",
+        "defaultTextColor": "",
+        "delimiter": ".",
+        "displayTemplate": "_value_",
+        "enable_bgColor": false,
+        "enable_bgColor_overrides": false,
+        "enable_clickable_cells": false,
+        "enable_textColor": false,
+        "enable_textColor_overrides": false,
+        "enable_time_based_thresholds": false,
+        "enable_transform": false,
+        "enable_transform_overrides": false,
+        "filter": {
+          "value_above": "",
+          "value_below": ""
+        },
+        "format": "none",
+        "name": "Default Pattern",
+        "null_color": "darkred",
+        "null_textcolor": "black",
+        "null_value": "No data",
+        "pattern": "*",
+        "row_col_wrapper": "_",
+        "row_name": "_series_",
+        "textColors": "red|orange|green",
+        "textColors_overrides": "0->red|2->green|1->yellow",
+        "thresholds": "70,90",
+        "time_based_thresholds": [],
+        "tooltipTemplate": "Series : _series_ <br/>Row Name : _row_name_ <br/>Col Name : _col_name_ <br/>Value : _value_",
+        "transform_values": "_value_|_value_|_value_",
+        "transform_values_overrides": "0->down|1->up",
+        "valueName": "avg"
+      },
+      "default_title_for_rows": "Metric",
+      "gridPos": {
+        "h": 19,
+        "w": 9,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "options": {},
+      "patterns": [
+        {
+          "bgColors": "red|orange|green",
+          "bgColors_overrides": "0->green|2->red|1->yellow",
+          "clickable_cells_link": "",
+          "col_name": "_1_",
+          "decimals": "0",
+          "defaultBGColor": "",
+          "defaultTextColor": "",
+          "delimiter": "|",
+          "displayTemplate": "_value_",
+          "enable_bgColor": false,
+          "enable_bgColor_overrides": false,
+          "enable_clickable_cells": false,
+          "enable_textColor": false,
+          "enable_textColor_overrides": false,
+          "enable_time_based_thresholds": false,
+          "enable_transform": false,
+          "enable_transform_overrides": false,
+          "filter": {
+            "value_above": "",
+            "value_below": ""
+          },
+          "format": "none",
+          "name": "mem",
+          "null_color": "darkred",
+          "null_textcolor": "black",
+          "null_value": "No data",
+          "pattern": "mem$",
+          "row_col_wrapper": "_",
+          "row_name": "_0_",
+          "textColors": "red|orange|green",
+          "textColors_overrides": "0->red|2->green|1->yellow",
+          "thresholds": "10,50",
+          "time_based_thresholds": [],
+          "tooltipTemplate": "Series : _series_ <br/>Row Name : _row_name_ <br/>Col Name : _col_name_ <br/>Value : _value_",
+          "transform_values": "_value_|_value_|_value_",
+          "transform_values_overrides": "0->down|1->up",
+          "valueName": "current"
+        },
+        {
+          "bgColors": "green|orange|red",
+          "bgColors_overrides": "0->green|2->red|1->yellow",
+          "clickable_cells_link": "",
+          "col_name": "_1_",
+          "decimals": "0",
+          "defaultBGColor": "",
+          "defaultTextColor": "",
+          "delimiter": "|",
+          "displayTemplate": "_value_",
+          "enable_bgColor": false,
+          "enable_bgColor_overrides": false,
+          "enable_clickable_cells": false,
+          "enable_textColor": false,
+          "enable_textColor_overrides": false,
+          "enable_time_based_thresholds": false,
+          "enable_transform": false,
+          "enable_transform_overrides": false,
+          "filter": {
+            "value_above": "",
+            "value_below": ""
+          },
+          "format": "none",
+          "name": "other",
+          "null_color": "darkred",
+          "null_textcolor": "black",
+          "null_value": "No data",
+          "pattern": "",
+          "row_col_wrapper": "_",
+          "row_name": "_0_",
+          "textColors": "red|orange|green",
+          "textColors_overrides": "0->red|2->green|1->yellow",
+          "thresholds": "5,10",
+          "time_based_thresholds": [],
+          "tooltipTemplate": "Series : _series_ <br/>Row Name : _row_name_ <br/>Col Name : _col_name_ <br/>Value : _value_",
+          "transform_values": "_value_|_value_|_value_",
+          "transform_values_overrides": "0->down|1->up",
+          "valueName": "current"
+        }
+      ],
+      "pluginVersion": "6.6.0",
+      "row_col_wrapper": "_",
+      "sorting_props": {
+        "col_index": -1,
+        "direction": "desc"
+      },
+      "targets": [
+        {
+          "expr": "app_req",
+          "instant": true,
+          "legendFormat": "{{app}} | {{dim}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "app_req",
+      "type": "yesoreyeram-boomtable-panel"
+    },
+    {
+      "activePatternIndex": 0,
+      "datasource": "Prometheus-operator",
+      "defaultPattern": {
+        "bgColors": "green|orange|red",
+        "bgColors_overrides": "0->green|2->red|1->yellow",
+        "clickable_cells_link": "",
+        "col_name": "Value",
+        "decimals": 2,
+        "defaultBGColor": "",
+        "defaultTextColor": "",
+        "delimiter": ".",
+        "displayTemplate": "_value_",
+        "enable_bgColor": false,
+        "enable_bgColor_overrides": false,
+        "enable_clickable_cells": false,
+        "enable_textColor": false,
+        "enable_textColor_overrides": false,
+        "enable_time_based_thresholds": false,
+        "enable_transform": false,
+        "enable_transform_overrides": false,
+        "filter": {
+          "value_above": "",
+          "value_below": ""
+        },
+        "format": "none",
+        "name": "Default Pattern",
+        "null_color": "darkred",
+        "null_textcolor": "black",
+        "null_value": "No data",
+        "pattern": "*",
+        "row_col_wrapper": "_",
+        "row_name": "_series_",
+        "textColors": "red|orange|green",
+        "textColors_overrides": "0->red|2->green|1->yellow",
+        "thresholds": "70,90",
+        "time_based_thresholds": [],
+        "tooltipTemplate": "Series : _series_ <br/>Row Name : _row_name_ <br/>Col Name : _col_name_ <br/>Value : _value_",
+        "transform_values": "_value_|_value_|_value_",
+        "transform_values_overrides": "0->down|1->up",
+        "valueName": "avg"
+      },
+      "default_title_for_rows": "Metric",
+      "gridPos": {
+        "h": 14,
+        "w": 15,
+        "x": 9,
+        "y": 0
+      },
+      "id": 3,
+      "options": {},
+      "patterns": [
+        {
+          "bgColors": "green|orange|red",
+          "bgColors_overrides": "0->green|2->red|1->yellow",
+          "clickable_cells_link": "",
+          "col_name": "_1_",
+          "decimals": "0",
+          "defaultBGColor": "",
+          "defaultTextColor": "",
+          "delimiter": "|",
+          "displayTemplate": "_value_",
+          "enable_bgColor": false,
+          "enable_bgColor_overrides": false,
+          "enable_clickable_cells": false,
+          "enable_textColor": false,
+          "enable_textColor_overrides": false,
+          "enable_time_based_thresholds": false,
+          "enable_transform": false,
+          "enable_transform_overrides": false,
+          "filter": {
+            "value_above": "",
+            "value_below": ""
+          },
+          "format": "none",
+          "name": "app",
+          "null_color": "darkred",
+          "null_textcolor": "black",
+          "null_value": "No data",
+          "pattern": "",
+          "row_col_wrapper": "_",
+          "row_name": "_0_",
+          "textColors": "red|orange|green",
+          "textColors_overrides": "0->red|2->green|1->yellow",
+          "thresholds": "70,90",
+          "time_based_thresholds": [],
+          "tooltipTemplate": "Series : _series_ <br/>Row Name : _row_name_ <br/>Col Name : _col_name_ <br/>Value : _value_",
+          "transform_values": "_value_|_value_|_value_",
+          "transform_values_overrides": "0->down|1->up",
+          "valueName": "current"
+        }
+      ],
+      "pluginVersion": "6.6.0",
+      "row_col_wrapper": "_",
+      "sorting_props": {
+        "col_index": -1,
+        "direction": "desc"
+      },
+      "targets": [
+        {
+          "expr": "node_capacity",
+          "instant": true,
+          "legendFormat": "{{node}} | {{dim}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "node_capacity",
+      "type": "yesoreyeram-boomtable-panel"
+    },
+    {
+      "datasource": null,
+      "gridPos": {
+        "h": 5,
+        "w": 15,
+        "x": 9,
+        "y": 14
+      },
+      "id": 7,
+      "options": {
+        "colorMode": "value",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "decimals": 1,
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "value": 1
+                },
+                {
+                  "color": "red",
+                  "value": 10
+                }
+              ]
+            },
+            "title": ""
+          },
+          "overrides": [],
+          "values": false
+        },
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto"
+      },
+      "pluginVersion": "6.6.0",
+      "targets": [
+        {
+          "expr": "profile_nodes_by_cpu{memory=\"2lm\"}",
+          "legendFormat": "{{index}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "profile_nodes_by_cpu{memory=\"2lm\"}",
+      "type": "stat"
+    },
+    {
+      "activePatternIndex": 0,
+      "datasource": "Prometheus-operator",
+      "defaultPattern": {
+        "bgColors": "green|orange|red",
+        "bgColors_overrides": "0->green|2->red|1->yellow",
+        "clickable_cells_link": "",
+        "col_name": "Value",
+        "decimals": "0",
+        "defaultBGColor": "",
+        "defaultTextColor": "",
+        "delimiter": "|",
+        "displayTemplate": "_value_",
+        "enable_bgColor": false,
+        "enable_bgColor_overrides": false,
+        "enable_clickable_cells": false,
+        "enable_textColor": false,
+        "enable_textColor_overrides": false,
+        "enable_time_based_thresholds": false,
+        "enable_transform": false,
+        "enable_transform_overrides": false,
+        "filter": {
+          "value_above": "",
+          "value_below": ""
+        },
+        "format": "none",
+        "name": "Default Pattern",
+        "null_color": "darkred",
+        "null_textcolor": "black",
+        "null_value": "No data",
+        "pattern": "*",
+        "row_col_wrapper": "_",
+        "row_name": "_series_",
+        "textColors": "red|orange|green",
+        "textColors_overrides": "0->red|2->green|1->yellow",
+        "thresholds": "70,90",
+        "time_based_thresholds": [],
+        "tooltipTemplate": "Series : _series_ <br/>Row Name : _row_name_ <br/>Col Name : _col_name_ <br/>Value : _value_",
+        "transform_values": "_value_|_value_|_value_",
+        "transform_values_overrides": "0->down|1->up",
+        "valueName": "avg"
+      },
+      "default_title_for_rows": "Metric",
+      "gridPos": {
+        "h": 19,
+        "w": 9,
+        "x": 0,
+        "y": 19
+      },
+      "id": 5,
+      "options": {},
+      "patterns": [
+        {
+          "bgColors": "red|orange|green",
+          "bgColors_overrides": "0->green|2->red|1->yellow",
+          "clickable_cells_link": "",
+          "col_name": "_1_",
+          "decimals": "1",
+          "defaultBGColor": "",
+          "defaultTextColor": "",
+          "delimiter": "|",
+          "displayTemplate": "_value_",
+          "enable_bgColor": true,
+          "enable_bgColor_overrides": false,
+          "enable_clickable_cells": false,
+          "enable_textColor": false,
+          "enable_textColor_overrides": false,
+          "enable_time_based_thresholds": false,
+          "enable_transform": false,
+          "enable_transform_overrides": false,
+          "filter": {
+            "value_above": "",
+            "value_below": ""
+          },
+          "format": "none",
+          "name": "app-mem_density",
+          "null_color": "darkred",
+          "null_textcolor": "black",
+          "null_value": "No data",
+          "pattern": "mem_density",
+          "row_col_wrapper": "_",
+          "row_name": "_0_",
+          "textColors": "red|orange|green",
+          "textColors_overrides": "0->red|2->green|1->yellow",
+          "thresholds": "0.1,0.5",
+          "time_based_thresholds": [],
+          "tooltipTemplate": "Series : _series_ <br/>Row Name : _row_name_ <br/>Col Name : _col_name_ <br/>Value : _value_",
+          "transform_values": "_value_|_value_|_value_",
+          "transform_values_overrides": "0->down|1->up",
+          "valueName": "current"
+        },
+        {
+          "bgColors": "green|orange|red",
+          "bgColors_overrides": "0->green|2->red|1->yellow",
+          "clickable_cells_link": "",
+          "col_name": "_1_",
+          "decimals": 2,
+          "defaultBGColor": "",
+          "defaultTextColor": "",
+          "delimiter": "|",
+          "displayTemplate": "_value_",
+          "enable_bgColor": true,
+          "enable_bgColor_overrides": false,
+          "enable_clickable_cells": false,
+          "enable_textColor": false,
+          "enable_textColor_overrides": false,
+          "enable_time_based_thresholds": false,
+          "enable_transform": false,
+          "enable_transform_overrides": false,
+          "filter": {
+            "value_above": "",
+            "value_below": ""
+          },
+          "format": "none",
+          "name": "others",
+          "null_color": "darkred",
+          "null_textcolor": "black",
+          "null_value": "No data",
+          "pattern": "",
+          "row_col_wrapper": "_",
+          "row_name": "_0_",
+          "textColors": "red|orange|green",
+          "textColors_overrides": "0->red|2->green|1->yellow",
+          "thresholds": "1,3",
+          "time_based_thresholds": [],
+          "tooltipTemplate": "Series : _series_ <br/>Row Name : _row_name_ <br/>Col Name : _col_name_ <br/>Value : _value_",
+          "transform_values": "_value_|_value_|_value_",
+          "transform_values_overrides": "0->down|1->up",
+          "valueName": "avg"
+        }
+      ],
+      "pluginVersion": "6.6.0",
+      "row_col_wrapper": "_",
+      "sorting_props": {
+        "col_index": -1,
+        "direction": "desc"
+      },
+      "targets": [
+        {
+          "expr": "profile_app_by_cpu_norm",
+          "instant": true,
+          "legendFormat": "{{app}} | {{index}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "profile_app_by_cpu_norm",
+      "type": "yesoreyeram-boomtable-panel"
+    },
+    {
+      "datasource": null,
+      "gridPos": {
+        "h": 5,
+        "w": 15,
+        "x": 9,
+        "y": 19
+      },
+      "id": 12,
+      "options": {
+        "colorMode": "value",
+        "fieldOptions": {
+          "calcs": [
+            "last"
+          ],
+          "defaults": {
+            "decimals": 1,
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "#EAB839",
+                  "value": 1
+                },
+                {
+                  "color": "red",
+                  "value": 10
+                }
+              ]
+            },
+            "title": ""
+          },
+          "overrides": [],
+          "values": false
+        },
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto"
+      },
+      "pluginVersion": "6.6.0",
+      "targets": [
+        {
+          "expr": "profile_nodes_by_cpu{memory=\"1lm\"}",
+          "legendFormat": "{{index}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "profile_nodes_by_cpu{memory=\"1lm\"}",
+      "type": "stat"
+    },
+    {
+      "activePatternIndex": 0,
+      "datasource": "Prometheus-operator",
+      "defaultPattern": {
+        "bgColors": "green|orange|red",
+        "bgColors_overrides": "0->green|2->red|1->yellow",
+        "clickable_cells_link": "",
+        "col_name": "Value",
+        "decimals": 2,
+        "defaultBGColor": "",
+        "defaultTextColor": "",
+        "delimiter": ".",
+        "displayTemplate": "_value_",
+        "enable_bgColor": false,
+        "enable_bgColor_overrides": false,
+        "enable_clickable_cells": false,
+        "enable_textColor": false,
+        "enable_textColor_overrides": false,
+        "enable_time_based_thresholds": false,
+        "enable_transform": false,
+        "enable_transform_overrides": false,
+        "filter": {
+          "value_above": "",
+          "value_below": ""
+        },
+        "format": "none",
+        "name": "Default Pattern",
+        "null_color": "darkred",
+        "null_textcolor": "black",
+        "null_value": "No data",
+        "pattern": "*",
+        "row_col_wrapper": "_",
+        "row_name": "_series_",
+        "textColors": "red|orange|green",
+        "textColors_overrides": "0->red|2->green|1->yellow",
+        "thresholds": "70,90",
+        "time_based_thresholds": [],
+        "tooltipTemplate": "Series : _series_ <br/>Row Name : _row_name_ <br/>Col Name : _col_name_ <br/>Value : _value_",
+        "transform_values": "_value_|_value_|_value_",
+        "transform_values_overrides": "0->down|1->up",
+        "valueName": "avg"
+      },
+      "default_title_for_rows": "Metric",
+      "gridPos": {
+        "h": 19,
+        "w": 4,
+        "x": 9,
+        "y": 24
+      },
+      "id": 9,
+      "options": {},
+      "patterns": [
+        {
+          "bgColors": "red|orange|green",
+          "bgColors_overrides": "0->green|2->red|1->yellow",
+          "clickable_cells_link": "",
+          "col_name": "_1_",
+          "decimals": "2",
+          "defaultBGColor": "",
+          "defaultTextColor": "",
+          "delimiter": "|",
+          "displayTemplate": "_value_",
+          "enable_bgColor": true,
+          "enable_bgColor_overrides": false,
+          "enable_clickable_cells": false,
+          "enable_textColor": false,
+          "enable_textColor_overrides": false,
+          "enable_time_based_thresholds": false,
+          "enable_transform": false,
+          "enable_transform_overrides": false,
+          "filter": {
+            "value_above": "",
+            "value_below": ""
+          },
+          "format": "none",
+          "name": "SCORE",
+          "null_color": "darkred",
+          "null_textcolor": "black",
+          "null_value": "No data",
+          "pattern": "",
+          "row_col_wrapper": "_",
+          "row_name": "_0_",
+          "textColors": "red|orange|green",
+          "textColors_overrides": "0->red|2->green|1->yellow",
+          "thresholds": "-3,-0.3",
+          "time_based_thresholds": [],
+          "tooltipTemplate": "Series : _series_ <br/>Row Name : _row_name_ <br/>Col Name : _col_name_ <br/>Value : _value_",
+          "transform_values": "_value_|_value_|_value_",
+          "transform_values_overrides": "0->down|1->up",
+          "valueName": "current"
+        }
+      ],
+      "pluginVersion": "6.6.0",
+      "row_col_wrapper": "_",
+      "sorting_props": {
+        "col_index": 0,
+        "direction": "desc"
+      },
+      "targets": [
+        {
+          "expr": "profile_app_2lm_score_max",
+          "instant": true,
+          "legendFormat": "{{app}} | SCORE(max)",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "profile_app_by_cpu_norm",
+      "type": "yesoreyeram-boomtable-panel"
+    },
+    {
+      "content": "\nDefintion | Unit | Equation | Description\n------------ | ---- | ---------| ----\n**mem_density** | `[GB/cpu]`  | `mem` / `cpu` | higher is better \n**mem_intensity (read/write)** | `[GBs/cpu]` | `mbw` / `cpu` | lower is better \n**mem_utilization** | `[GB/cpu]` | `wss` / `cpu` | lower is better\n**SCORE**    | |  `mem_density` - `max`(`mem_intensity`, `mem_utilization`) | higher is better\n\n\n\n\n\n\n\n",
+      "datasource": null,
+      "gridPos": {
+        "h": 10,
+        "w": 11,
+        "x": 13,
+        "y": 24
+      },
+      "id": 11,
+      "mode": "markdown",
+      "options": {},
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Legend",
+      "type": "text"
+    }
+  ],
+  "schemaVersion": 22,
+  "style": "dark",
+  "tags": [
+    "2lm"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-1m",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
+  "timezone": "",
+  "title": "2LM score dashboard",
+  "uid": "Wh9lRnXWk",
+  "version": 17
+}

--- a/examples/kubernetes/monitoring/prometheus/kustomization.yaml
+++ b/examples/kubernetes/monitoring/prometheus/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - prometheus.yaml
   - prometheus_rule.app.yaml
   - prometheus_rule.apm.yaml
+  - prometheus_rule.score.yaml
   - prometheus_rule.16-compatibility-rules-new-to-old.yaml
   - service_account.yaml
   - service.yaml

--- a/examples/kubernetes/monitoring/prometheus/prometheus_rule.score.yaml
+++ b/examples/kubernetes/monitoring/prometheus/prometheus_rule.score.yaml
@@ -15,7 +15,7 @@ spec:
     # end following units: cpu, GB, GB, GBs, GBs
     # node_capacity 
     #   -> profile_node_by_cpu with memory=[1lm, 2lm]
-    #       -> profile_node_by_cpu_2lm (only for 2LM)
+    #       -> profile_nodes_by_cpu_2lm (only for 2LM)
     # 
     #
     # ---- For applications ------------
@@ -29,6 +29,11 @@ spec:
     # app_mbw, app_mbw_rw, app_mbw_read, app_mbw_write
     #   -> app_req
     #     -> profile_app_by_cpu
+    #
+    # Profle final metrics:
+    #  profile_nodes_by_cpu_2lm
+    #  profile_app_by_cpu_norm
+    #    -> profile_app_by_cpu_norm 
 
 
 
@@ -82,19 +87,19 @@ spec:
     - record: profile_node_by_cpu
       expr: 'node_capacity{dim="mem"} / on (node) node_capacity{dim="cpu"}'
       labels:
-        dim: mem_density
+        index: mem_density
     - record: profile_node_by_cpu
       expr: 'node_capacity{dim="mbw_read"} / on (node) node_capacity{dim="cpu"}'
       labels:
-        dim: mem_intensity_read
+        index: mem_intensity_read
     - record: profile_node_by_cpu
       expr: 'node_capacity{dim="mbw_write"} / on (node) node_capacity{dim="cpu"}'
       labels:
-        dim: mem_intensity_write
+        index: mem_intensity_write
     - record: profile_node_by_cpu
       expr: 'node_capacity{dim="wss"} / on (node) node_capacity{dim="cpu"}'
       labels:
-        dim: mem_utilization
+        index: mem_utilization
 
     # By specifc nodes
     - record: profile_nodes_by_cpu
@@ -107,7 +112,7 @@ spec:
         memory: 2lm
 
     # Average nvm profile
-    - record: profile_node_by_cpu_2lm
+    - record: profile_nodes_by_cpu_2lm
       expr: avg(profile_nodes_by_cpu{memory="2lm"}) by (dim)
 
     # ============================ apps ===================================
@@ -176,34 +181,34 @@ spec:
     - record: profile_app_by_cpu
       expr: app_mem / app_cpu
       labels:
-        dim: mem_density
+        index: mem_density
     - record: profile_app_by_cpu
       expr: app_mbw_read / app_cpu
       labels:
-        dim: mem_intensity_read
+        index: mem_intensity_read
     - record: profile_app_by_cpu
       expr: app_mbw_read / app_cpu
       labels:
-        dim: mem_intensity_write
+        index: mem_intensity_write
     - record: profile_app_by_cpu
       expr: app_wss / app_cpu
       labels:
-        dim: mem_utilization
+        index: mem_utilization
 
 
     # ======================== normalization profile ========================
     - record: profile_app_by_cpu_norm
-      expr: profile_app_by_cpu / on(dim) group_left profile_node_by_cpu_2lm
+      expr: profile_app_by_cpu / on(dim) group_left profile_nodes_by_cpu_2lm
 
     # ======================== SCORE calculation ==========================
     - record: profile_app_2lm_score_positive # higher is better for 2lm
-      expr: profile_app_by_cpu_norm{dim="mem_density"}
+      expr: profile_app_by_cpu_norm{index="mem_density"}
 
     - record: profile_app_2lm_score_negative_sum # lower is better for 2lm
-      expr: sum(profile_app_by_cpu_norm{dim=~"mem_intensity_read|mem_intensity_write|mem_utilization"}) by (app)
+      expr: sum(profile_app_by_cpu_norm{index=~"mem_intensity_read|mem_intensity_write|mem_utilization"}) by (app)
 
     - record: profile_app_2lm_score_negative_max # lower is better for 2lm
-      expr: max(profile_app_by_cpu_norm{dim=~"mem_intensity_read|mem_intensity_write|mem_utilization"}) by (app)
+      expr: max(profile_app_by_cpu_norm{index=~"mem_intensity_read|mem_intensity_write|mem_utilization"}) by (app)
 
     - record: profile_app_2lm_score_max # higher is better for 2lm
       expr: profile_app_2lm_score_positive - on(app) profile_app_2lm_score_negative_max

--- a/examples/kubernetes/monitoring/prometheus/prometheus_rule.score.yaml
+++ b/examples/kubernetes/monitoring/prometheus/prometheus_rule.score.yaml
@@ -1,0 +1,202 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    role: prometheus-rules
+  name: prometheus-wca-app
+spec: 
+  groups:
+
+  - name: score
+
+    # ---- For nodes -----------------------
+    # New metrics with folowing dim=[cpu, mem, wss, mbw_write, mbw_read]
+    # end following units: cpu, GB, GB, GBs, GBs
+    # node_capacity 
+    #   -> profile_node_by_cpu with memory=[1lm, 2lm]
+    #       -> profile_node_by_cpu_2lm (only for 2LM)
+    # 
+    #
+    # ---- For applications ------------
+    # app_count
+    # low level:
+    #
+    # WARNING all level metrics take an average of 1d for tasks
+    # app_cpu, app_cpu_usage -> app_cpu_util
+    # app_mem, app_mem_usage -> app_mem_util
+    # app_req with dim=[cpu, mem, wss, mbw_write, mbw_read]
+    # app_mbw, app_mbw_rw, app_mbw_read, app_mbw_write
+    #   -> app_req
+
+
+
+    rules:
+    # ============================ node ===================================
+    # cpu
+    - record: node_capacity
+      expr: 'sum(platform_topology_cpus) by (node)'
+      labels:
+        dim: cpu
+    # Mem capacity and wss
+    - record: node_capacity
+      expr: 'ceil(sum(platform_dimm_total_size_bytes{dimm_type="ram"}) by (node) / 1e9)'
+      labels:
+        dim: wss
+    - record: node_capacity
+      expr: 'ceil(sum(platform_dimm_total_size_bytes{dimm_type="ram"}) by (node) / 1e9) and on(node) platform_mem_mode_size_bytes==0'
+      labels:
+        dim: mem
+    - record: node_capacity
+      expr: 'ceil((sum(platform_mem_mode_size_bytes) by (node) / 1e9)) and on(node) platform_mem_mode_size_bytes!=0'
+      labels:
+        dim: mem
+    # BW
+    - record: node_capacity
+      expr: 'ceil(sum(platform_nvdimm_read_bandwidth_bytes_per_second) by (node) / 1e9) and on(node) platform_mem_mode_size_bytes!=0'
+      labels:
+        dim: mbw_read
+    - record: node_capacity
+      expr: 'ceil(sum(platform_dimm_speed_bytes_per_second) by (node) / 1e9) and on(node) platform_mem_mode_size_bytes==0'
+      labels:
+        dim: mbw_read
+    - record: node_capacity
+      expr: 'ceil(sum(platform_nvdimm_write_bandwidth_bytes_per_second) by (node) / 1e9) and on(node) platform_mem_mode_size_bytes!=0'
+      labels:
+        dim: mbw_write
+    - record: node_capacity
+      expr: 'ceil(sum(platform_dimm_speed_bytes_per_second) by (node) / 1e9) and on(node) platform_mem_mode_size_bytes==0'
+      labels:
+        dim: mbw_write
+    
+    # ---------------------------- node nvm profile -----------------------------------------
+    # nvm profile only catch pmm nodes!!!!
+    # # and on(node) platform_mem_mode_size_bytes!=0
+    - record: profile_node_by_cpu
+      expr: 'ceil(node_capacity{dim="mem"} / on (node) node_capacity{dim="cpu"})'
+      labels:
+        dim: mem_density
+    - record: profile_node_by_cpu
+      expr: 'ceil(node_capacity{dim="mbw_read"} / on (node) node_capacity{dim="cpu"})'
+      labels:
+        dim: mem_intensity_read
+    - record: profile_node_by_cpu
+      expr: 'ceil(node_capacity{dim="mbw_write"} / on (node) node_capacity{dim="cpu"})'
+      labels:
+        dim: mem_intensity_write
+    - record: profile_node_by_cpu
+      expr: 'ceil(node_capacity{dim="wss"} / on (node) node_capacity{dim="cpu"})'
+      labels:
+        dim: mem_utilization
+
+    - record: profile_node_by_cpu
+      expr: 'profile_node_by_cpu and on(node) platform_mem_mode_size_bytes==0'
+      labels:
+        memory: 1lm
+    - record: profile_node_by_cpu
+      expr: 'profile_node_by_cpu and on(node) platform_mem_mode_size_bytes!=0'
+      labels:
+        memory: 2lm
+
+    # Average nvm profile
+    - record: profile_node_by_cpu_2lm
+      expr: avg(profile_node_by_cpu{memory="2lm"}) by (dim)
+
+    # ============================ apps ===================================
+    - record: app_count
+      expr: count(task_up) by (app)
+
+    # very low metric
+    - record: task_memory_rw_ratio
+      expr: rate(task_offcore_requests_demand_data_rd[1d]) / (rate(task_offcore_requests_demand_data_rd[1d]) + rate(task_offcore_requests_demand_rfo[1d]))
+
+    # ---- low level metrics for apps [1d]
+    - record: app_cpu
+      expr: avg(max_over_time(task_requested_cpus[1d])) by (app)
+    - record: app_cpu_usage
+      expr: ceil(avg(rate(task_cpu_usage_seconds[1d])) by (app))
+    - record: app_cpu_util
+      expr: app_cpu_usage/app_cpu
+
+    - record: app_mem
+      expr: avg(max_over_time(task_requested_mem_bytes[1d])) by (app) / 1e9
+    - record: app_mem_usage
+      expr: avg(avg_over_time(task_mem_usage_bytes[1d])) by(app) / 1e9
+    - record: app_mem_util
+      expr: app_mem_usage/app_mem
+
+    # ---- mem bandwidth [gb/s]
+    - record: app_mbw
+      expr: avg(rate(task_mem_bandwidth_bytes[1d])) by (app) / 1e9
+    # ---- r/w and read/write bandwidth
+    - record: app_mbw_rw
+      expr: ceil(avg(task_memory_rw_ratio) by (app))
+    - record: app_mbw_read
+      expr: ceil(app_mbw * app_mbw_rw)
+    - record: app_mbw_write
+      expr: ceil(app_mbw * (1-app_mbw_rw))
+    # --- wss [gb]
+    - record: app_wss   # gb collected over 15s
+      expr: ceil((avg(avg_over_time(task_wss_referenced_bytes[1d])) by (app)) / 1e9)
+
+    # just a mapping app_req to use labels: cpu, mem, mbw_read, mbw_write, wss
+    - record: app_req
+      expr: app_cpu
+      labels:
+        dim: cpu
+    - record: app_req
+      expr: app_mem
+      labels:
+        dim: mem
+    - record: app_req
+      expr: app_mbw_read
+      labels:
+        dim: mbw_read
+    - record: app_req
+      expr: app_mbw_write
+      labels:
+        dim: mbw_write
+    - record: app_req
+      expr: app_wss
+      labels:
+        dim: wss
+
+
+    # --------------------- Profiles APP -----------------------
+
+    # app profile
+    - record: profile_app_by_cpu
+      expr: app_mem / app_cpu
+      labels:
+        dim: mem_density
+    - record: profile_app_by_cpu
+      expr: app_mbw_read / app_cpu
+      labels:
+        dim: mem_intensity_read
+    - record: profile_app_by_cpu
+      expr: app_mbw_read / app_cpu
+      labels:
+        dim: mem_intensity_write
+    - record: profile_app_by_cpu
+      expr: app_wss / app_cpu
+      labels:
+        dim: mem_utilization
+
+
+    # ======================== normalization profile ========================
+    - record: profile_app_by_cpu_norm
+      expr: profile_app_by_cpu / on(dim) group_left profile_node_by_cpu_2lm
+
+    # ======================== SCORE calculation ==========================
+    - record: profile_app_2lm_score_positive # higher is better for 2lm
+      expr: profile_app_by_cpu_norm{dim="mem_density"}
+
+    - record: profile_app_2lm_score_negative_sum # lower is better for 2lm
+      expr: sum(profile_app_by_cpu_norm{dim=~"mem_intensity_read|mem_intensity_write|mem_utilization"}) by (app)
+
+    - record: profile_app_2lm_score_negative_max # lower is better for 2lm
+      expr: max(profile_app_by_cpu_norm{dim=~"mem_intensity_read|mem_intensity_write|mem_utilization"}) by (app)
+
+    - record: profile_app_2lm_score_max # higher is better for 2lm
+      expr: profile_app_2lm_score_positive - on(app) profile_app_2lm_score_negative_max
+    - record: profile_app_2lm_score_sum # higher is better for 2lm
+      expr: profile_app_2lm_score_positive - on(app) profile_app_2lm_score_negative_sum

--- a/examples/kubernetes/monitoring/prometheus/prometheus_rule.score.yaml
+++ b/examples/kubernetes/monitoring/prometheus/prometheus_rule.score.yaml
@@ -179,19 +179,19 @@ spec:
 
     # app profile
     - record: profile_app_by_cpu
-      expr: app_mem / app_cpu
+      expr: app_req{dim="mem"} / on(app) app_req{dim="cpu"}
       labels:
         index: mem_density
     - record: profile_app_by_cpu
-      expr: app_mbw_read / app_cpu
+      expr: app_req{dim="mbw_read"} / on(app) app_req{dim="cpu"}
       labels:
         index: mem_intensity_read
     - record: profile_app_by_cpu
-      expr: app_mbw_read / app_cpu
+      expr: app_req{dim="mbw_write"} / on(app) app_req{dim="cpu"}
       labels:
         index: mem_intensity_write
     - record: profile_app_by_cpu
-      expr: app_wss / app_cpu
+      expr: app_req{dim="wss"} / on(app) app_req{dim="cpu"}
       labels:
         index: mem_utilization
 

--- a/examples/kubernetes/monitoring/prometheus/prometheus_rule.score.yaml
+++ b/examples/kubernetes/monitoring/prometheus/prometheus_rule.score.yaml
@@ -28,6 +28,7 @@ spec:
     # app_req with dim=[cpu, mem, wss, mbw_write, mbw_read]
     # app_mbw, app_mbw_rw, app_mbw_read, app_mbw_write
     #   -> app_req
+    #     -> profile_app_by_cpu
 
 
 

--- a/examples/kubernetes/monitoring/prometheus/prometheus_rule.score.yaml
+++ b/examples/kubernetes/monitoring/prometheus/prometheus_rule.score.yaml
@@ -30,9 +30,10 @@ spec:
     #   -> app_req
     #     -> profile_app_by_cpu
     #
-    # Profle final metrics:
-    #  profile_nodes_by_cpu_2lm
-    #  profile_app_by_cpu_norm
+    # ---- Profiles -----------------------
+    # with index=[mem_density, mem_intesity_read, mem_intesity_write, mem_utilization]
+    #  profile_nodes_by_cpu
+    #  profile_app_by_cpu
     #    -> profile_app_by_cpu_norm 
 
 
@@ -103,17 +104,13 @@ spec:
 
     # By specifc nodes
     - record: profile_nodes_by_cpu
-      expr: 'profile_node_by_cpu and on(node) platform_mem_mode_size_bytes==0'
+      expr: 'avg(profile_node_by_cpu and on(node) platform_mem_mode_size_bytes==0) by (index)'
       labels:
         memory: 1lm
     - record: profile_nodes_by_cpu
-      expr: 'profile_node_by_cpu and on(node) platform_mem_mode_size_bytes!=0'
+      expr: 'avg(profile_node_by_cpu and on(node) platform_mem_mode_size_bytes!=0) by (index)'
       labels:
         memory: 2lm
-
-    # Average nvm profile
-    - record: profile_nodes_by_cpu_2lm
-      expr: avg(profile_nodes_by_cpu{memory="2lm"}) by (dim)
 
     # ============================ apps ===================================
     - record: app_count
@@ -198,7 +195,7 @@ spec:
 
     # ======================== normalization profile ========================
     - record: profile_app_by_cpu_norm
-      expr: profile_app_by_cpu / on(dim) group_left profile_nodes_by_cpu_2lm
+      expr: profile_app_by_cpu / on(dim) group_left profile_nodes_by_cpu{memory="2lm"}
 
     # ======================== SCORE calculation ==========================
     - record: profile_app_2lm_score_positive # higher is better for 2lm

--- a/examples/kubernetes/monitoring/prometheus/prometheus_rule.score.yaml
+++ b/examples/kubernetes/monitoring/prometheus/prometheus_rule.score.yaml
@@ -3,7 +3,8 @@ kind: PrometheusRule
 metadata:
   labels:
     role: prometheus-rules
-  name: prometheus-wca-app
+  name: prometheus-wca-score
+  namespace: prometheus
 spec: 
   groups:
 
@@ -126,10 +127,10 @@ spec:
 
     # ---- mem bandwidth [gb/s]
     - record: app_mbw
-      expr: avg(rate(task_mem_bandwidth_bytes[1d])) by (app) / 1e9
+      expr: max(irate(task_mem_bandwidth_bytes[1d])) by (app) / 1e9
     # ---- r/w and read/write bandwidth
     - record: app_mbw_rw
-      expr: ceil(avg(task_memory_rw_ratio) by (app))
+      expr: avg(task_memory_rw_ratio) by (app)
     - record: app_mbw_read
       expr: ceil(app_mbw * app_mbw_rw)
     - record: app_mbw_write

--- a/examples/kubernetes/monitoring/prometheus/prometheus_rule.score.yaml
+++ b/examples/kubernetes/monitoring/prometheus/prometheus_rule.score.yaml
@@ -195,7 +195,7 @@ spec:
 
     # ======================== normalization profile ========================
     - record: profile_app_by_cpu_norm
-      expr: profile_app_by_cpu / on(dim) group_left profile_nodes_by_cpu{memory="2lm"}
+      expr: profile_app_by_cpu / on(index) group_left profile_nodes_by_cpu{memory="2lm"}
 
     # ======================== SCORE calculation ==========================
     - record: profile_app_2lm_score_positive # higher is better for 2lm

--- a/examples/kubernetes/monitoring/prometheus/prometheus_rule.score.yaml
+++ b/examples/kubernetes/monitoring/prometheus/prometheus_rule.score.yaml
@@ -40,8 +40,14 @@ spec:
       labels:
         dim: cpu
     # Mem capacity and wss
+    # -- wss on 2lm is devaulated to 10% because of direct mapping
     - record: node_capacity
-      expr: 'ceil(sum(platform_dimm_total_size_bytes{dimm_type="ram"}) by (node) / 1e9)'
+      expr: 'ceil(sum(platform_dimm_total_size_bytes{dimm_type="ram"}) by (node) * 0.1 / 1e9) and on(node) platform_mem_mode_size_bytes!=0'
+      labels:
+        dim: wss
+    # -- ws on 1lm nodes is just capacity of ram
+    - record: node_capacity
+      expr: 'ceil(sum(platform_dimm_total_size_bytes{dimm_type="ram"}) by (node) / 1e9) and on(node) platform_mem_mode_size_bytes==0'
       labels:
         dim: wss
     - record: node_capacity
@@ -74,34 +80,35 @@ spec:
     # nvm profile only catch pmm nodes!!!!
     # # and on(node) platform_mem_mode_size_bytes!=0
     - record: profile_node_by_cpu
-      expr: 'ceil(node_capacity{dim="mem"} / on (node) node_capacity{dim="cpu"})'
+      expr: 'node_capacity{dim="mem"} / on (node) node_capacity{dim="cpu"}'
       labels:
         dim: mem_density
     - record: profile_node_by_cpu
-      expr: 'ceil(node_capacity{dim="mbw_read"} / on (node) node_capacity{dim="cpu"})'
+      expr: 'node_capacity{dim="mbw_read"} / on (node) node_capacity{dim="cpu"}'
       labels:
         dim: mem_intensity_read
     - record: profile_node_by_cpu
-      expr: 'ceil(node_capacity{dim="mbw_write"} / on (node) node_capacity{dim="cpu"})'
+      expr: 'node_capacity{dim="mbw_write"} / on (node) node_capacity{dim="cpu"}'
       labels:
         dim: mem_intensity_write
     - record: profile_node_by_cpu
-      expr: 'ceil(node_capacity{dim="wss"} / on (node) node_capacity{dim="cpu"})'
+      expr: 'node_capacity{dim="wss"} / on (node) node_capacity{dim="cpu"}'
       labels:
         dim: mem_utilization
 
-    - record: profile_node_by_cpu
+    # By specifc nodes
+    - record: profile_nodes_by_cpu
       expr: 'profile_node_by_cpu and on(node) platform_mem_mode_size_bytes==0'
       labels:
         memory: 1lm
-    - record: profile_node_by_cpu
+    - record: profile_nodes_by_cpu
       expr: 'profile_node_by_cpu and on(node) platform_mem_mode_size_bytes!=0'
       labels:
         memory: 2lm
 
     # Average nvm profile
     - record: profile_node_by_cpu_2lm
-      expr: avg(profile_node_by_cpu{memory="2lm"}) by (dim)
+      expr: avg(profile_nodes_by_cpu{memory="2lm"}) by (dim)
 
     # ============================ apps ===================================
     - record: app_count


### PR DESCRIPTION
Provides a intermediate and final metrics to calaculating score for 2LM average node.   

List of metrics:
 
- For nodes (**dim**=[cpu, mem, wss, mbw_write, mbw_read]) and following units: cpu, GB, GB, GBs, GBs
  - `node_capacity`
  - `profile_nodes_by_cpu` with index=[mem_density, mem_intensity_read, mem_intensity_write, mem_utilization] 
  - `profile_nodes_by_cpu` with memory=[1lm, 2lm]
- For applications
  - `app_count`
  - low level metrics # WARNING all level metrics take an average of 1d for tasks - need to be modified to shorter time before production use
    - `app_cpu`, `app_cpu_usage` [cpu] -> `app_cpu_util` [%]
    - `app_mem`, app_mem_usage` [GB]-> `app_mem_util` [%]
    - `app_mbw` [GBs], `app_mbw_rw` [%s], `app_mbw_read` [GBs], `app_mbw_write` [GBs]
    - `app_wss` [GB]
  - all above metrics are put into single with 
    - `app_req` with dim=[cpu, mem, wss, mbw_write, mbw_read]
    - and "application profile" is created `profile_app_by_cpu` **index**=[mem_density, mem_intesity_read, mem_intesity_write, mem_utilization]
    
Finally based on `profile_nodes_by_cpu` and `profile_app_by_cpu` - we're creating "normalized profile"
`profile_app_by_cpu_norm` and the scores:

`profile_app_2lm_score_max` and `profile_app_2lm_score_avg` that is based on `profile_app_by_cpu_norm`
