### PR TITLE
Fix bug in calculating Score2 in prometheus rules. 

### DIFF
--- a/examples/kubernetes/monitoring/prometheus/prometheus_rule.score.yaml
+++ b/examples/kubernetes/monitoring/prometheus/prometheus_rule.score.yaml
@@ -234,9 +234,6 @@ spec:
     - record: profile_app_2lm_score_sum # higher is better for 2lm
       expr: profile_app_2lm_score_positive - on(app) group_left() profile_app_2lm_score_negative_sum
 
-    - record: drozdzan_test # higher is better for 2lm
-      expr: profile_app_by_cpu
-
     # ======================== SCORE2 calculation ==========================
     - record: profile_app_2lm_score2_negative_max # lower is better for 2lm
       expr: -1 * max(profile_app_by_mem_norm{index=~"cpu_density|mem_intensity_read|mem_intensity_write|mem_utilization"}) by (app)

--- a/examples/kubernetes/monitoring/prometheus/prometheus_rule.score.yaml
+++ b/examples/kubernetes/monitoring/prometheus/prometheus_rule.score.yaml
@@ -9,35 +9,6 @@ spec:
   groups:
 
   - name: score
-
-    # ---- For nodes -----------------------
-    # New metrics with following dim=[cpu, mem, wss, mbw_write, mbw_read]
-    # end following units: cpu, GB, GB, GBs, GBs
-    # node_capacity 
-    #   -> profile_node_by_cpu with memory=[1lm, 2lm]
-    #       -> profile_nodes_by_cpu_2lm (only for 2LM)
-    # 
-    #
-    # ---- For applications ------------
-    # app_count
-    # low level:
-    #
-    # WARNING all level metrics take an average of 10m for tasks
-    # app_cpu, app_cpu_usage -> app_cpu_util
-    # app_mem, app_mem_usage -> app_mem_util
-    # app_req with dim=[cpu, mem, wss, mbw_write, mbw_read]
-    # app_mbw, app_mbw_rw, app_mbw_read, app_mbw_write
-    #   -> app_req
-    #     -> profile_app_by_cpu
-    #
-    # ---- Profiles -----------------------
-    # with index=[mem_density, mem_intesity_read, mem_intesity_write, mem_utilization]
-    #  profile_nodes_by_cpu
-    #  profile_app_by_cpu
-    #    -> profile_app_by_cpu_norm 
-
-
-
     rules:
     # ============================ node ===================================
     # cpu
@@ -267,22 +238,8 @@ spec:
       expr: profile_app_by_cpu
 
     # ======================== SCORE2 calculation ==========================
-    - record: profile_app_2lm_score2_positive # higher is better for 2lm
-      expr: profile_app_by_mem_norm{index="cpu_density"}
-
-    - record: profile_app_2lm_score2_negative_sum # lower is better for 2lm
-      expr: sum(profile_app_by_mem_norm{index=~"mem_intensity_read|mem_intensity_write|mem_utilization"}) by (app)
-
     - record: profile_app_2lm_score2_negative_max # lower is better for 2lm
-      expr: max(profile_app_by_mem_norm{index=~"mem_intensity_read|mem_intensity_write|mem_utilization"}) by (app)
-
-    - record: profile_app_2lm_score2_max # higher is better for 2lm
-      expr: profile_app_2lm_score2_positive - on(app) group_left() profile_app_2lm_score2_negative_max
-    - record: profile_app_2lm_score2_sum # higher is better for 2lm
-      expr: profile_app_2lm_score2_positive - on(app) group_left() profile_app_2lm_score2_negative_sum
-
-    - record: drozdzan_test # higher is better for 2lm
-      expr: profile_app_by_mem
+      expr: -1 * max(profile_app_by_mem_norm{index=~"cpu_density|mem_intensity_read|mem_intensity_write|mem_utilization"}) by (app)
 
   - name: cluster-score-data-provider
     rules:
@@ -302,4 +259,4 @@ spec:
           nodetype: unknown
       
       - record: app_profile
-        expr: 'profile_app_2lm_score_max'
+        expr: 'profile_app_2lm_score2_negative_max'

--- a/examples/kubernetes/wca-scheduler/config.yaml
+++ b/examples/kubernetes/wca-scheduler/config.yaml
@@ -20,7 +20,7 @@ algorithm: !Score
       host: http://100.64.176.36
       port: 30900
       timeout: 5.0
-      time: "1586212811"  # Date: 2020-04-06 22:40:11
+      time: "1586245624"  # Date: 2020-04-07 07:47:04
     queries: !Queries
       APP_REQUESTED_RESOURCES_QUERY_MAP:
             cpu: 'ceil(max(max_over_time(task_requested_cpus[10m])) by (app))'

--- a/examples/kubernetes/wca-scheduler/config.yaml
+++ b/examples/kubernetes/wca-scheduler/config.yaml
@@ -6,7 +6,7 @@ kubeapi: &kubeapi !Kubeapi
   port: !Env KUBERNETES_SERVICE_PORT
 # reschedule_interval: 5
 algorithm: !Score
-  score_target: -2.0
+  score_target: -3.0
   max_node_score: 10000.
   dimensions:
     - mem
@@ -20,7 +20,7 @@ algorithm: !Score
       host: http://100.64.176.36
       port: 30900
       timeout: 5.0
-      time: "1584646650"  # Date: 2020-03-19 19:37:30
+      time: "1586212811"  # Date: 2020-04-06 22:40:11
     queries: !Queries
       APP_REQUESTED_RESOURCES_QUERY_MAP:
             cpu: 'ceil(max(max_over_time(task_requested_cpus[10m])) by (app))'


### PR DESCRIPTION
Modify config after retuning.
Set Score2 as default.
cpu_density was lacking in calculations.