### PR TITLE
Change prometheus metric apm_hammerdb_ops

### DIFF
--- a/examples/kubernetes/monitoring/prometheus/prometheus_rule.apm.yaml
+++ b/examples/kubernetes/monitoring/prometheus/prometheus_rule.apm.yaml
@@ -100,7 +100,7 @@ spec:
         - record: apm_hammerdb_alive
           expr: ceil(rate(apm_hammerdb_stdout_lines[30s])>0)
         - record: apm_hammerdb_ops
-          expr: avg_over_time(apm_hammerdb_tpm[90s]) and apm_hammerdb_tpm_gauge_alive
+          expr: avg_over_time(apm_hammerdb_tpm[90s]) / 60 and apm_hammerdb_tpm_gauge_alive # it is collecting TPM (Transaction Per Minute) and it is necessary to change minutes to seconds to collect ops
         - record: apm_hammerdb_latency
           expr: avg_over_time(apm_hammerdb_latency_stdout[1m]) and ignoring(quantile, type_query) apm_hammerdb_alive
         # common apm metrics


### PR DESCRIPTION
It is collecting TPM (Transaction Per Minute) and it is necessary to change minutes to seconds to collect ops. I set dividing by 60 in prometheus metric apm_hammerdb_ops to get ops.

The second solution is to move python script to bash script in the pod, to get more flexibility in defining collecting metric.