### PR TITLE
memtier_benchmark with --requests=allkeys

### DIFF
--- a/examples/kubernetes/workloads/redis-memtier/base/redis-memtier.yaml
+++ b/examples/kubernetes/workloads/redis-memtier/base/redis-memtier.yaml
@@ -93,7 +93,7 @@ spec:
               stdbuf -e0 -o0
               memtier_benchmark
               --run-count=9999
-              --requests=10000000000
+              --requests=allkeys
               --server=$target
               --threads=$threads
               --hide-histogram


### PR DESCRIPTION
I wonder that memtrier_benchmark should be set like this ` --requests=allkeys`. In this way, it requests about all keys or maybe we cover some keys? 