### PR TITLE
vmstat(s) global and per NUMA node for all keys

### DIFF
--- a/tests/fixtures/proc-vmstat-simple.txt
+++ b/tests/fixtures/proc-vmstat-simple.txt
@@ -1,0 +1,2 @@
+nr_foo 20
+nr_bar 30

--- a/tests/test_platforms.py
+++ b/tests/test_platforms.py
@@ -154,6 +154,8 @@ def test_parse_node_distances(*mocks):
 @patch('wca.platforms.read_proc_meminfo', return_value='does not matter, because parse is mocked')
 @patch('wca.platforms.parse_proc_stat', return_value={0: 100, 1: 200})
 @patch('wca.platforms.parse_node_cpus', return_value={})
+@patch('wca.vmstat.parse_node_vmstat_keys', return_value={})
+@patch('wca.vmstat.parse_proc_vmstat_keys', return_value={})
 @patch('wca.platforms.parse_proc_vmstat',
        return_value={MetricName.PLATFORM_VMSTAT_NUMA_PAGES_MIGRATED: 5})
 @patch('wca.platforms.parse_node_distances', return_value={})

--- a/tests/test_vmstat.py
+++ b/tests/test_vmstat.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2020 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from unittest.mock import patch
+
+from tests.testing import create_open_mock, relative_module_path
+from wca import vmstat
+
+
+@patch('builtins.open', new=create_open_mock({
+    '/sys/devices/system/node/node0/vmstat': open(
+        relative_module_path(__file__, 'fixtures/proc-vmstat-simple.txt')).read(),
+    '/sys/devices/system/node/node1/vmstat': open(
+        relative_module_path(__file__, 'fixtures/proc-vmstat-simple.txt')).read()
+}))
+@patch('os.listdir', return_value=['node0', 'node1'])
+def test_parse_node_meminfo(*mocks):
+    measurements = vmstat.parse_node_vmstat_keys()
+    assert measurements == {
+        'platform_node_vmstat':
+            {0: {'nr_bar': 30, 'nr_foo': 20},
+             1: {'nr_bar': 30, 'nr_foo': 20}}
+    }
+
+
+@patch('builtins.open', new=create_open_mock({
+    "/proc/vmstat": open(relative_module_path(__file__, 'fixtures/proc-vmstat-simple.txt')).read(),
+}))
+def test_parse_proc_vmstat_keys(*mocks):
+    measurements = vmstat.parse_proc_vmstat_keys()
+    assert measurements == {'platform_vmstat': {'nr_bar': 30, 'nr_foo': 20}}

--- a/wca/metrics.py
+++ b/wca/metrics.py
@@ -115,6 +115,8 @@ class MetricName(str, Enum):
     PLATFORM_VMSTAT_NUMA_HINT_FAULTS = 'platform_vmstat_numa_hint_faults'
     PLATFORM_VMSTAT_NUMA_HINT_FAULTS_LOCAL = 'platform_vmstat_numa_hint_faults_local'
     PLATFORM_VMSTAT_PGFAULTS = 'platform_vmstat_pgfaults'
+    PLATFORM_VMSTAT = 'platform_vmstat'
+    PLATFORM_NODE_VMSTAT = 'platform_node_vmstat'
 
     # Perf event based from uncore PMU and derived
     PLATFORM_PMM_BANDWIDTH_READS = 'platform_pmm_bandwidth_reads'
@@ -865,6 +867,26 @@ METRICS_METADATA: Dict[MetricName, MetricMetadata] = {
             MetricSource.PROCFS,
             MetricGranularity.PLATFORM,
             [],
+            'yes'
+        ),
+    MetricName.PLATFORM_VMSTAT:
+        MetricMetadata(
+            'Virtual Memory stats based on /proc/vmstat - all possible keys',
+            MetricType.COUNTER,
+            MetricUnit.NUMERIC,
+            MetricSource.PROCFS,
+            MetricGranularity.PLATFORM,
+            ['key'],
+            'yes'
+        ),
+    MetricName.PLATFORM_NODE_VMSTAT:
+        MetricMetadata(
+            'Virtual Memory stats based on /sys/devices/system/node/nodeX/vmstat',
+            MetricType.COUNTER,
+            MetricUnit.NUMERIC,
+            MetricSource.PROCFS,
+            MetricGranularity.PLATFORM,
+            ['numa_node', 'key'],
             'yes'
         ),
     # Perf uncore

--- a/wca/platforms.py
+++ b/wca/platforms.py
@@ -27,6 +27,7 @@ from enum import Enum
 from wca.metrics import Metric, MetricName, Measurements, export_metrics_from_measurements
 from wca.profiling import profiler
 from wca.logger import TRACE
+from wca import vmstat
 
 try:
     from pkg_resources import get_distribution, DistributionNotFound
@@ -666,6 +667,9 @@ def collect_platform_information(rdt_enabled: bool = True,
     platform_measurements.update(platform_static_information)
 
     platform_measurements.update(parse_proc_vmstat())
+
+    platform_measurements.update(vmstat.parse_node_vmstat_keys())
+    platform_measurements.update(vmstat.parse_proc_vmstat_keys())
 
     platform = Platform(
         sockets=no_of_sockets,

--- a/wca/vmstat.py
+++ b/wca/vmstat.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2020 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+
+from typing import Dict
+from wca.metrics import MetricName, Measurements
+
+
+def _parse_vmstat(vmstat_filename) -> Dict[str, int]:
+    measurements = {}
+    with open(vmstat_filename) as f:
+        for line in f.readlines():
+            key, value = line.split()
+            measurements[key] = int(value)
+    return measurements
+
+
+BASE_SYSFS_NODES_PATH = '/sys/devices/system/node'
+
+
+def parse_node_vmstat_keys() -> Measurements:
+    """Parses /sys/devices/system/node/node*/vmstat
+    """
+    measurements = {}
+    for nodedir in os.listdir(BASE_SYSFS_NODES_PATH):
+        if nodedir.startswith('node'):
+            node_id = int(nodedir[4:])
+            vmstat_filename = os.path.join(BASE_SYSFS_NODES_PATH, nodedir, 'vmstat')
+            measurements[node_id] = _parse_vmstat(vmstat_filename)
+    return {MetricName.PLATFORM_NODE_VMSTAT: measurements}
+
+
+def parse_proc_vmstat_keys() -> Measurements:
+    """Parses /proc/vmstat """
+    return {MetricName.PLATFORM_VMSTAT: _parse_vmstat('/proc/vmstat')}


### PR DESCRIPTION
Only limited number of vmstats were available currently.

This PR collects all keys from both:
- /proc/vmstat
- /sys/devices/system/node/nodeX/vmstat

and exposes them as new two metrics

platform_vmstat with key label
and 
**platform_node_vmstat** with numa_node and key labels